### PR TITLE
Necromancer class

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <p>Move: WASD or Arrow Keys</p>
       <p>Archer: Left click to fire arrows (hold for auto-fire)</p>
       <p>Warrior: Left click to swing a melee strike</p>
+      <p>Necromancer: Hold left click to command undead, right click for death bolt</p>
       <p>Archer Skill: Right click fire arrow (2s cooldown, AoE + 1s burn zone)</p>
       <p>Goal: Find the key, open the door, survive escalating enemy waves.</p>
       <section id="character-select" class="character-select" aria-label="Character selection">
@@ -25,6 +26,10 @@
           <button type="button" class="class-option" data-class-option="warrior" aria-pressed="false">
             <strong>Castle Warrior</strong>
             <span>Melee cleaves, higher base damage, brawler playstyle.</span>
+          </button>
+          <button type="button" class="class-option" data-class-option="necromancer" aria-pressed="false">
+            <strong>Reformed Necromancer</strong>
+            <span>Charm undead pets, sustain them with necrotic light, detonate the dead.</span>
           </button>
         </div>
         <button type="button" id="start-game" class="start-game">Start Local Run</button>

--- a/server/networkServer.js
+++ b/server/networkServer.js
@@ -38,7 +38,7 @@ function clamp(v, lo, hi) {
 
 
 function normClassType(value) {
-  return value === "fighter" || value === "warrior" ? "fighter" : "archer";
+  return value === "fighter" || value === "warrior" ? "fighter" : value === "necromancer" ? "necromancer" : "archer";
 }
 
 function makeDefaultInput() {

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,7 @@ export const CONFIG = {
       key: "fighter",
       label: "Castle Warrior",
       usesRanged: false,
+      combatStyle: "warrior",
       baseLifeLeech: 0.02,
       baseMaxHealth: 125,
       baseDefenseFlat: 2.5,
@@ -35,6 +36,24 @@ export const CONFIG = {
       passiveRegenPct: 0.02,
       levelHpGain: 10,
       levelWeaponDamagePct: 0.05
+    },
+    necromancer: {
+      key: "necromancer",
+      label: "Reformed Necromancer",
+      usesRanged: true,
+      combatStyle: "necromancer",
+      baseLifeLeech: 0,
+      baseMaxHealth: 88,
+      baseDefenseFlat: 0,
+      baseMoveSpeed: 148,
+      baseAttackCooldown: 0.08,
+      minAttackCooldown: 0.08,
+      primaryDamageMin: 0,
+      primaryDamageMax: 0,
+      projectileSpeed: 0,
+      passiveRegenPct: 0.01,
+      levelHpGain: 7,
+      levelWeaponDamagePct: 0.03
     }
   },
   map: {
@@ -241,6 +260,32 @@ export const CONFIG = {
     blastRadiusPerLevel: 2.6,
     lingerDuration: 1.0,
     lingerDps: 3.6
+  },
+  necromancer: {
+    controlRangeTiles: 10,
+    charmDuration: 2.0,
+    minCharmDuration: 0.5,
+    beamWidth: 11,
+    healTickSeconds: 0.2,
+    healAmount: 3,
+    healSelfCost: 1,
+    baseControlCap: 2,
+    followDistanceTiles: 2.2,
+    leashDistanceTiles: 4.5,
+    aggroRangeTiles: 6.5,
+    petBuffPerRank: 0.15
+  },
+  deathBolt: {
+    cooldown: 10,
+    hpCostPct: 0.05,
+    speed: 165,
+    life: 1.6,
+    impactRadiusTiles: 2,
+    visualLife: 5,
+    pulseInterval: 1
+  },
+  explodingDeath: {
+    radiusTiles: 3
   },
   warriorRage: {
     duration: 10,

--- a/src/game/GameRuntimeBase.js
+++ b/src/game/GameRuntimeBase.js
@@ -18,7 +18,10 @@ export class GameRuntimeBase {
     };
     this.ctx = this.canvas.getContext ? this.canvas.getContext("2d") : null;
     this.config = CONFIG;
-    this.classType = options.classType === "fighter" ? "fighter" : "archer";
+    this.classType =
+      options.classType === "fighter" || options.classType === "necromancer"
+        ? options.classType
+        : "archer";
     this.classSpec = this.config.classes[this.classType] || this.config.classes.archer;
     this.onReturnToMenu = typeof options.onReturnToMenu === "function" ? options.onReturnToMenu : null;
     this.onPauseChanged = typeof options.onPauseChanged === "function" ? options.onPauseChanged : null;
@@ -78,11 +81,22 @@ export class GameRuntimeBase {
       multiarrow: { key: "multiarrow", label: "Multiarrow", points: 0, maxPoints: 8 },
       warriorMomentum: { key: "warriorMomentum", label: "Frenzy", points: 0, maxPoints: 8 },
       warriorRage: { key: "warriorRage", label: "Rage", points: 0, maxPoints: 8 },
-      warriorExecute: { key: "warriorExecute", label: "Execute", points: 0, maxPoints: 8 }
+      warriorExecute: { key: "warriorExecute", label: "Execute", points: 0, maxPoints: 8 },
+      undeadMastery: { key: "undeadMastery", label: "Control Mastery", points: 0, maxPoints: 4 },
+      deathBolt: { key: "deathBolt", label: "Death Bolt", points: 0, maxPoints: 8 },
+      explodingDeath: { key: "explodingDeath", label: "Augment Death", points: 0, maxPoints: 8 }
     };
     this.warriorMomentumTimer = 0;
     this.warriorRageActiveTimer = 0;
     this.warriorRageCooldownTimer = 0;
+    this.necromancerBeam = {
+      active: false,
+      targetId: null,
+      targetX: 0,
+      targetY: 0,
+      progress: 0,
+      healTickTimer: 0
+    };
     this.upgrades = {
       moveSpeed: { key: "moveSpeed", label: "Move Speed", baseCost: 80, costScale: 1.28, level: 0, maxLevel: 20 },
       enemySpawnRate: { key: "enemySpawnRate", label: "Enemy Spawn Rate", baseCost: 60, costScale: 1.25, level: 0, maxLevel: 15 },
@@ -102,6 +116,7 @@ export class GameRuntimeBase {
       maxHealth: Number.isFinite(this.classSpec.baseMaxHealth) ? this.classSpec.baseMaxHealth : this.config.player.maxHealth,
       fireCooldown: 0,
       fireArrowCooldown: 0,
+      deathBoltCooldown: 0,
       dirX: 1,
       dirY: 0,
       facing: 0,
@@ -217,6 +232,14 @@ export class GameRuntimeBase {
     this.warriorMomentumTimer = 0;
     this.warriorRageActiveTimer = 0;
     this.warriorRageCooldownTimer = 0;
+    this.necromancerBeam = {
+      active: false,
+      targetId: null,
+      targetX: 0,
+      targetY: 0,
+      progress: 0,
+      healTickTimer: 0
+    };
     this.navDistance = Array.from({ length: this.map.length }, () => Array(this.map[0].length).fill(-1));
     this.navPlayerTile = { x: -1, y: -1 };
     this.hasKey = false;
@@ -231,6 +254,9 @@ export class GameRuntimeBase {
   }
 
   advanceToNextFloor() {
+    const controlledUndead = (this.enemies || [])
+      .filter((enemy) => enemy?.isControlledUndead && (enemy.hp || 0) > 0 && !(enemy.type === "skeleton_warrior" && enemy.collapsed))
+      .map((enemy) => ({ ...enemy }));
     const persisted = {
       gold: this.gold,
       skillPoints: this.skillPoints,
@@ -246,6 +272,26 @@ export class GameRuntimeBase {
     this.skillPoints = persisted.skillPoints;
     this.player.maxHealth = persisted.maxHealth;
     this.player.health = Math.min(this.player.maxHealth, persisted.health);
+    if (controlledUndead.length > 0) {
+      const tile = this.config.map.tile;
+      controlledUndead.forEach((enemy, index) => {
+        const ring = 1 + Math.floor(index / 4);
+        const angle = (index / Math.max(1, controlledUndead.length)) * Math.PI * 2;
+        const spawn = this.findNearestSafePoint(
+          this.player.x + Math.cos(angle) * ring * tile * 1.1,
+          this.player.y + Math.sin(angle) * ring * tile * 1.1,
+          10
+        );
+        enemy.x = spawn.x;
+        enemy.y = spawn.y;
+        enemy.lastX = enemy.x;
+        enemy.lastY = enemy.y;
+        enemy.collapsed = false;
+        enemy.collapseTimer = 0;
+        enemy.reviveAtEnd = false;
+      });
+      this.enemies.push(...controlledUndead);
+    }
     if (typeof this.onFloorChanged === "function") this.onFloorChanged(this.floor, this);
   }
 
@@ -259,6 +305,192 @@ export class GameRuntimeBase {
 
   getPlayerMoveSpeed() {
     return this.classSpec.baseMoveSpeed * this.getMoveSpeedMultiplier() * this.getWarriorMomentumMultiplier();
+  }
+
+  isArcherClass() {
+    return this.classType === "archer";
+  }
+
+  isWarriorClass() {
+    return this.classType === "fighter";
+  }
+
+  isNecromancerClass() {
+    return this.classType === "necromancer";
+  }
+
+  isUndeadEnemy(enemy) {
+    return enemy?.type === "ghost" || enemy?.type === "skeleton_warrior";
+  }
+
+  isControlledUndead(enemy) {
+    return !!enemy?.isControlledUndead;
+  }
+
+  isEnemyFriendlyToPlayer(enemy) {
+    return this.isControlledUndead(enemy);
+  }
+
+  isEnemyHostileToPlayer(enemy) {
+    return !!enemy && !this.isEnemyFriendlyToPlayer(enemy);
+  }
+
+  getNecromancerControlCap(points = this.skills.undeadMastery.points) {
+    const p = Number.isFinite(points) ? Math.max(0, Math.floor(points)) : 0;
+    const base = Number.isFinite(this.config.necromancer?.baseControlCap) ? this.config.necromancer.baseControlCap : 1;
+    return Math.min(5, base + p);
+  }
+
+  getNecromancerCharmDuration(points = this.skills.undeadMastery.points) {
+    const maxPoints = Number.isFinite(this.skills?.undeadMastery?.maxPoints) ? this.skills.undeadMastery.maxPoints : 4;
+    const p = Number.isFinite(points) ? Math.max(0, points) : 0;
+    const base = Number.isFinite(this.config.necromancer?.charmDuration) ? this.config.necromancer.charmDuration : 2;
+    const min = Number.isFinite(this.config.necromancer?.minCharmDuration) ? this.config.necromancer.minCharmDuration : 0.5;
+    const denom = Math.log1p(1.2 * Math.max(1, maxPoints));
+    const norm = denom > 0 ? Math.log1p(1.2 * Math.min(maxPoints, p)) / denom : 1;
+    return base - (base - min) * Math.max(0, Math.min(1, norm));
+  }
+
+  getControlledUndeadCount() {
+    return (this.enemies || []).filter((enemy) => this.isControlledUndead(enemy) && (enemy.hp || 0) > 0).length;
+  }
+
+  getControlledUndeadBoost(points = this.skills.explodingDeath.points) {
+    const perRank = Number.isFinite(this.config.necromancer?.petBuffPerRank) ? this.config.necromancer.petBuffPerRank : 0.2;
+    const p = Number.isFinite(points) ? Math.max(0, points) : 0;
+    return 1 + perRank * p;
+  }
+
+  getControlledUndeadDefenseMultiplier(points = this.skills.explodingDeath.points) {
+    const p = Number.isFinite(points) ? Math.max(0, points) : 0;
+    return 1.5 + (0.2 * p);
+  }
+
+  getOverallAttackModifier() {
+    const classBase =
+      Number.isFinite(this.classSpec.primaryDamageMin) &&
+      Number.isFinite(this.classSpec.primaryDamageMax) &&
+      (this.classSpec.primaryDamageMin > 0 || this.classSpec.primaryDamageMax > 0)
+        ? (Math.abs(this.classSpec.primaryDamageMin) + Math.abs(this.classSpec.primaryDamageMax)) * 0.5
+        : (Number.isFinite(this.config.fireArrow?.impactDamage) ? this.config.fireArrow.impactDamage : 3.2);
+    const baseRef = Math.max(0.1, classBase);
+    return ((baseRef * this.getDamageMultiplier()) + Math.max(0, this.levelWeaponDamageBonus || 0)) / baseRef;
+  }
+
+  getDeathBoltBaseDamage(points = this.skills.deathBolt.points) {
+    const p = Number.isFinite(points) ? Math.max(0, points) : 0;
+    return this.getFireArrowImpactDamage(p) * 1.1 * this.getOverallAttackModifier();
+  }
+
+  getDeathBoltHealAmount(points = this.skills.deathBolt.points) {
+    return this.getDeathBoltBaseDamage(points) * 0.25;
+  }
+
+  getNecroticBeamHealAmount(points = this.skills.explodingDeath.points) {
+    const p = Number.isFinite(points) ? Math.max(0, points) : 0;
+    const base = (Number.isFinite(this.config.necromancer?.healAmount) ? this.config.necromancer.healAmount : 3) * this.getOverallAttackModifier();
+    return base * (1 + 0.15 * p);
+  }
+
+  getDeathBoltPetDamageMultiplier(points = this.skills.deathBolt.points) {
+    const p = Number.isFinite(points) ? Math.max(0, Math.floor(points)) : 0;
+    if (p < 5) return 1;
+    if (p < 7) return 1.5;
+    return 2;
+  }
+
+  getDeathExplosionDamage(points = this.skills.explodingDeath.points) {
+    const p = Number.isFinite(points) ? Math.max(0, points - 2) : 0;
+    if (p <= 0) return 0;
+    const base = ((this.config.enemy.skeletonWarriorDamageMin || 10) + (this.config.enemy.skeletonWarriorDamageMax || 16)) * 0.5;
+    return base * (1 + 0.45 * Math.log1p(1.15 * p));
+  }
+
+  getDeathBoltRadius() {
+    const tile = this.config.map.tile;
+    return (Number.isFinite(this.config.deathBolt?.impactRadiusTiles) ? this.config.deathBolt.impactRadiusTiles : 2) * tile;
+  }
+
+  getExplodingDeathRadius() {
+    const tile = this.config.map.tile;
+    return (Number.isFinite(this.config.explodingDeath?.radiusTiles) ? this.config.explodingDeath.radiusTiles : 3) * tile;
+  }
+
+  canControlMoreUndead() {
+    return this.getControlledUndeadCount() < this.getNecromancerControlCap();
+  }
+
+  applyControlledUndeadBonuses(enemy) {
+    if (!enemy || !this.isControlledUndead(enemy)) return enemy;
+    const boost = this.getControlledUndeadBoost();
+    const baseMaxHp = Number.isFinite(enemy.baseMaxHp) ? enemy.baseMaxHp : enemy.maxHp;
+    const baseSpeed = Number.isFinite(enemy.baseSpeed) ? enemy.baseSpeed : enemy.speed;
+    const baseMin = Number.isFinite(enemy.baseDamageMin) ? enemy.baseDamageMin : enemy.damageMin;
+    const baseMax = Number.isFinite(enemy.baseDamageMax) ? enemy.baseDamageMax : enemy.damageMax;
+    enemy.baseMaxHp = baseMaxHp;
+    enemy.baseSpeed = baseSpeed;
+    enemy.baseDamageMin = baseMin;
+    enemy.baseDamageMax = baseMax;
+    enemy.maxHp = Math.max(1, baseMaxHp * 3 * boost);
+    enemy.hp = Math.min(enemy.maxHp, Number.isFinite(enemy.hp * 3) ? enemy.hp * 3 : enemy.maxHp);
+    enemy.speed = Math.max(baseSpeed * boost, this.getPlayerMoveSpeed() * 1.1);
+    enemy.damageMin = baseMin * 1.3 * boost;
+    enemy.damageMax = baseMax * 1.3 * boost;
+    enemy.controlledDefenseMultiplier = this.getControlledUndeadDefenseMultiplier();
+    return enemy;
+  }
+
+  markUndeadAsControlled(enemy) {
+    if (!enemy || !this.isUndeadEnemy(enemy)) return false;
+    if (this.isControlledUndead(enemy)) return true;
+    if (!this.canControlMoreUndead()) return false;
+    enemy.isControlledUndead = true;
+    enemy.summonedByPlayer = true;
+    enemy.controlledAt = this.time;
+    enemy.hpBarTimer = this.config.enemy.hpBarDuration;
+    enemy.contactAttackCooldown = 0;
+    this.applyControlledUndeadBonuses(enemy);
+    return true;
+  }
+
+  healControlledUndead(enemy, amount) {
+    if (!enemy || !this.isControlledUndead(enemy) || !Number.isFinite(amount) || amount <= 0) return;
+    const before = enemy.hp;
+    enemy.hp = Math.min(enemy.maxHp, enemy.hp + amount);
+    if (enemy.hp > before) {
+      enemy.hpBarTimer = this.config.enemy.hpBarDuration;
+      this.spawnFloatingText(enemy.x, enemy.y - enemy.size * 0.7, `+${Math.max(1, Math.round(enemy.hp - before))}`, "#89b7ff", 0.8, 13);
+    }
+  }
+
+  findNearestSafePoint(x, y, maxRadiusTiles = 8) {
+    const tile = this.config.map.tile;
+    const tx = Math.floor(x / tile);
+    const ty = Math.floor(y / tile);
+    const isSafe = (cx, cy) => {
+      const px = cx * tile + tile * 0.5;
+      const py = cy * tile + tile * 0.5;
+      if (typeof this.isWalkableTile === "function") return this.isWalkableTile(cx, cy);
+      if (typeof this.isWallAt === "function") {
+        const r = Math.max(4, tile * 0.3);
+        return !this.isWallAt(px - r, py - r, true) && !this.isWallAt(px + r, py - r, true) &&
+          !this.isWallAt(px - r, py + r, true) && !this.isWallAt(px + r, py + r, true);
+      }
+      return true;
+    };
+    if (isSafe(tx, ty)) return { x: tx * tile + tile * 0.5, y: ty * tile + tile * 0.5 };
+    for (let radius = 1; radius <= maxRadiusTiles; radius++) {
+      for (let oy = -radius; oy <= radius; oy++) {
+        for (let ox = -radius; ox <= radius; ox++) {
+          if (Math.abs(ox) !== radius && Math.abs(oy) !== radius) continue;
+          const cx = tx + ox;
+          const cy = ty + oy;
+          if (!isSafe(cx, cy)) continue;
+          return { x: cx * tile + tile * 0.5, y: cy * tile + tile * 0.5 };
+        }
+      }
+    }
+    return { x: this.player.x, y: this.player.y };
   }
 
   getPlayerEnemyCollisionRadius() {

--- a/src/game/GameRuntimeSystems.js
+++ b/src/game/GameRuntimeSystems.js
@@ -17,6 +17,117 @@ import {
 import { GameRuntimeWorld } from "./GameRuntimeWorld.js";
 
 export class GameRuntimeSystems extends GameRuntimeWorld {
+  getControlledUndeadFormationPoint(enemy) {
+    const allies = (this.enemies || []).filter((entry) => this.isControlledUndead(entry) && (entry.hp || 0) > 0 && !(entry.type === "skeleton_warrior" && entry.collapsed));
+    const index = allies.indexOf(enemy);
+    const count = Math.max(1, allies.length);
+    const slot = index >= 0 ? index : 0;
+    const moveDx = (this.player.x || 0) - (this.player.lastX || this.player.x || 0);
+    const moveDy = (this.player.y || 0) - (this.player.lastY || this.player.y || 0);
+    const moveLen = vecLength(moveDx, moveDy);
+    if (moveLen > 0.2) {
+      this.player.formationDirX = moveDx / moveLen;
+      this.player.formationDirY = moveDy / moveLen;
+    }
+    const dirX = Number.isFinite(this.player.formationDirX) ? this.player.formationDirX : 0;
+    const dirY = Number.isFinite(this.player.formationDirY) ? this.player.formationDirY : 1;
+    const backX = -dirX;
+    const backY = -dirY;
+    const sideX = -backY;
+    const sideY = backX;
+    const spread = Math.min(Math.PI * 0.95, Math.PI * (0.45 + count * 0.12));
+    const t = count <= 1 ? 0.5 : slot / (count - 1);
+    const angle = -spread * 0.5 + spread * t;
+    const ring = 44 + Math.floor(slot / 5) * 22;
+    const offsetX = backX * Math.cos(angle) - sideX * Math.sin(angle);
+    const offsetY = backY * Math.cos(angle) - sideY * Math.sin(angle);
+    return {
+      x: this.player.x + offsetX * ring,
+      y: this.player.y + offsetY * ring
+    };
+  }
+
+  getEnemyTargetPoint(sourceEnemy) {
+    if (!sourceEnemy) return this.player;
+    const leash = (this.config.necromancer?.aggroRangeTiles || 6.5) * this.config.map.tile;
+    let best = this.player;
+    let bestDist = Number.POSITIVE_INFINITY;
+    const sourceFriendly = this.isEnemyFriendlyToPlayer(sourceEnemy);
+    const hasLineOfSight = (x0, y0, x1, y1) => {
+      const dx = x1 - x0;
+      const dy = y1 - y0;
+      const dist = vecLength(dx, dy);
+      if (dist <= 1) return true;
+      const tile = this.config?.map?.tile || 32;
+      const step = Math.max(8, tile * 0.35);
+      const steps = Math.max(1, Math.ceil(dist / step));
+      for (let i = 1; i < steps; i++) {
+        const t = i / steps;
+        const sx = x0 + dx * t;
+        const sy = y0 + dy * t;
+        if (this.isWallAt(sx, sy, false)) return false;
+      }
+      return true;
+    };
+    for (const enemy of this.enemies || []) {
+      if (!enemy || enemy === sourceEnemy || (enemy.hp || 0) <= 0) continue;
+      if (sourceFriendly && this.necromancerBeam?.active && this.necromancerBeam.targetEnemy === enemy) continue;
+      if (sourceFriendly && enemy.type === "mimic" && enemy.dormant) continue;
+      if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
+      const enemyFriendly = this.isEnemyFriendlyToPlayer(enemy);
+      if (enemyFriendly === sourceFriendly) continue;
+      if (sourceFriendly && !hasLineOfSight(sourceEnemy.x, sourceEnemy.y, enemy.x, enemy.y)) continue;
+      const dist = vecLength(enemy.x - sourceEnemy.x, enemy.y - sourceEnemy.y);
+      if (dist < bestDist && (sourceFriendly || dist <= leash)) {
+        best = enemy;
+        bestDist = dist;
+      }
+    }
+    if (!sourceFriendly) {
+      const playerDist = vecLength(this.player.x - sourceEnemy.x, this.player.y - sourceEnemy.y);
+      if (playerDist <= bestDist || best === this.player) return this.player;
+    }
+    return best;
+  }
+
+  moveEnemyTowardTarget(enemy, target, speedScale, dt, minDistance = 0) {
+    if (!enemy || !target) return;
+    const enemySpeed = Number.isFinite(enemy.speed) ? enemy.speed : 70;
+    const appliedScale = this.isEnemyFriendlyToPlayer(enemy) ? 1 : (Number.isFinite(speedScale) ? speedScale : 1);
+    const step = enemySpeed * appliedScale * Math.max(0, Number.isFinite(dt) ? dt : 0);
+    if (step <= 0) return;
+    const dx = target.x - enemy.x;
+    const dy = target.y - enemy.y;
+    const len = vecLength(dx, dy) || 1;
+    if (len <= minDistance) return;
+    const moveStep = Math.min(step, len - minDistance);
+    this.moveWithCollision(enemy, (dx / len) * moveStep, (dy / len) * moveStep);
+  }
+
+  updateGenericEnemy(enemy, dt, speedScale) {
+    const target = this.getEnemyTargetPoint(enemy);
+    if (this.isEnemyFriendlyToPlayer(enemy)) {
+      enemy.speed = Math.max(Number.isFinite(enemy.speed) ? enemy.speed : 0, this.getPlayerMoveSpeed() * 1.1);
+      const aggro = (this.config.necromancer?.aggroRangeTiles || 6.5) * this.config.map.tile;
+      const follow = (this.config.necromancer?.followDistanceTiles || 2.2) * this.config.map.tile;
+      if (target !== this.player && vecLength(target.x - enemy.x, target.y - enemy.y) <= aggro) {
+        this.moveEnemyTowardTarget(enemy, target, speedScale, dt, 6);
+      } else {
+        const anchor = this.getControlledUndeadFormationPoint(enemy);
+        const distToAnchor = vecLength(anchor.x - enemy.x, anchor.y - enemy.y);
+        if (distToAnchor > follow * 0.35) this.moveEnemyTowardTarget(enemy, anchor, speedScale, dt, 4);
+      }
+      return;
+    }
+    this.moveEnemyTowardTarget(
+      enemy,
+      target,
+      speedScale,
+      dt,
+      target === this.player ? this.getPlayerEnemyCollisionRadius() + enemy.size * 0.5 : 6
+    );
+  }
+
   fireWallTrap(trap) {
     if (!trap) return;
     const cfg = this.config?.traps?.wall || {};
@@ -130,6 +241,7 @@ export class GameRuntimeSystems extends GameRuntimeWorld {
   }
 
   fire(dx, dy) {
+    if (this.isNecromancerClass()) return;
     if (this.player.fireCooldown > 0) return;
     this.player.fireCooldown = this.getPlayerFireCooldown();
     if (!this.classSpec.usesRanged) {
@@ -224,6 +336,10 @@ export class GameRuntimeSystems extends GameRuntimeWorld {
   }
 
   fireFireArrow(dx, dy) {
+    if (this.isNecromancerClass()) {
+      this.fireDeathBolt(dx, dy);
+      return;
+    }
     if (!this.classSpec.usesRanged) {
       this.activateWarriorRage();
       return;
@@ -247,11 +363,81 @@ export class GameRuntimeSystems extends GameRuntimeWorld {
   triggerFireExplosion(x, y) {
     const blastRadius = this.getFireArrowBlastRadius();
     for (const enemy of this.enemies) {
+      if (this.isEnemyFriendlyToPlayer(enemy)) continue;
       if (vecLength(x - enemy.x, y - enemy.y) <= blastRadius + enemy.size * 0.3) {
         this.applyEnemyDamage(enemy, this.getFireArrowImpactDamage(), "fire");
       }
     }
-    this.fireZones.push({ x, y, radius: blastRadius * 0.9, life: this.config.fireArrow.lingerDuration });
+    this.fireZones.push({ x, y, radius: blastRadius * 0.9, life: this.config.fireArrow.lingerDuration, zoneType: "fire" });
+  }
+
+  fireDeathBolt(dx, dy) {
+    if (!this.isNecromancerClass()) return false;
+    if ((this.skills.deathBolt.points || 0) <= 0) return false;
+    if (this.player.deathBoltCooldown > 0) return false;
+    const hpCost = Math.max(1, this.player.maxHealth * (this.config.deathBolt?.hpCostPct || 0.05));
+    if (this.player.health <= hpCost) return false;
+    const origin = this.getBowMuzzleOrigin(dx, dy);
+    this.player.health = Math.max(1, this.player.health - hpCost);
+    this.markPlayerHealthBarVisible();
+    this.player.deathBoltCooldown = this.config.deathBolt?.cooldown || 10;
+    this.bullets.push({
+      x: origin.x,
+      y: origin.y,
+      vx: origin.dirX * (this.config.deathBolt?.speed || 165),
+      vy: origin.dirY * (this.config.deathBolt?.speed || 165),
+      angle: Math.atan2(origin.dirY, origin.dirX),
+      life: this.config.deathBolt?.life || 1.6,
+      size: 10,
+      projectileType: "deathBolt"
+    });
+    return true;
+  }
+
+  triggerDeathBoltExplosion(x, y) {
+    this.applyDeathBoltPulse(x, y);
+    this.fireZones.push({
+      x,
+      y,
+      radius: this.getDeathBoltRadius(),
+      life: this.config.deathBolt?.visualLife || 5,
+      pulseTimer: this.config.deathBolt?.pulseInterval || 1,
+      zoneType: "deathBolt"
+    });
+  }
+
+  applyDeathBoltPulse(x, y) {
+    const radius = this.getDeathBoltRadius();
+    const damage = this.getDeathBoltBaseDamage();
+    const healAmount = this.getDeathBoltHealAmount();
+    const petDamageMultiplier = this.getDeathBoltPetDamageMultiplier();
+    for (const enemy of this.enemies || []) {
+      if (!enemy || (enemy.hp || 0) <= 0) continue;
+      if (vecLength(enemy.x - x, enemy.y - y) > radius + (enemy.size || 20) * 0.35) continue;
+      if (this.isControlledUndead(enemy)) {
+        this.healControlledUndead(enemy, healAmount);
+        if (petDamageMultiplier > 1) {
+          enemy.damageBuffMultiplier = petDamageMultiplier;
+          enemy.damageBuffTimer = Math.max(Number.isFinite(enemy.damageBuffTimer) ? enemy.damageBuffTimer : 0, (this.config.deathBolt?.pulseInterval || 1) + 0.15);
+        }
+      } else {
+        this.applyEnemyDamage(enemy, damage, "death");
+      }
+    }
+  }
+
+  triggerExplodingDeath(sourceEnemy) {
+    if (!sourceEnemy || !this.isControlledUndead(sourceEnemy) || (this.skills.explodingDeath.points || 0) < 3) return;
+    const radius = this.getExplodingDeathRadius();
+    const damage = this.getDeathExplosionDamage();
+    for (const enemy of this.enemies || []) {
+      if (!enemy || enemy === sourceEnemy || (enemy.hp || 0) <= 0) continue;
+      if (this.isEnemyFriendlyToPlayer(enemy)) continue;
+      if (vecLength(enemy.x - sourceEnemy.x, enemy.y - sourceEnemy.y) <= radius + (enemy.size || 20) * 0.35) {
+        this.applyEnemyDamage(enemy, damage, "death");
+      }
+    }
+    this.fireZones.push({ x: sourceEnemy.x, y: sourceEnemy.y, radius, life: this.config.deathBolt?.visualLife || 0.35, zoneType: "deathBurst" });
   }
 
 }

--- a/src/game/enemySystems.js
+++ b/src/game/enemySystems.js
@@ -17,19 +17,58 @@ function hasLineOfSight(game, x0, y0, x1, y1) {
   return true;
 }
 
+function isFriendlyToPlayer(game, enemy) {
+  return typeof game?.isEnemyFriendlyToPlayer === "function" ? game.isEnemyFriendlyToPlayer(enemy) : !!enemy?.isControlledUndead;
+}
+
+function isHostilePair(game, source, target) {
+  if (!source || !target || source === target) return false;
+  return isFriendlyToPlayer(game, source) !== isFriendlyToPlayer(game, target);
+}
+
+function isActiveCharmTarget(game, enemy) {
+  return !!enemy && !!game?.necromancerBeam?.active && game.necromancerBeam.targetEnemy === enemy;
+}
+
+function getPriorityTarget(game, enemy, maxRange = Infinity) {
+  if (!enemy) return game.player;
+  const sourceFriendly = isFriendlyToPlayer(game, enemy);
+  let best = sourceFriendly ? null : game.player;
+  let bestDist = sourceFriendly ? Number.POSITIVE_INFINITY : vecLength(game.player.x - enemy.x, game.player.y - enemy.y);
+  for (const other of game.enemies || []) {
+    if (!other || !isHostilePair(game, enemy, other) || (other.hp || 0) <= 0) continue;
+    if (sourceFriendly && other.type === "mimic" && other.dormant) continue;
+    if (sourceFriendly && isActiveCharmTarget(game, other)) continue;
+    if (other.type === "skeleton_warrior" && other.collapsed) continue;
+    const dist = vecLength(other.x - enemy.x, other.y - enemy.y);
+    if (dist > maxRange) continue;
+    if (dist < bestDist) {
+      best = other;
+      bestDist = dist;
+    }
+  }
+  return best || game.player;
+}
+
 export function spawnGhost(game, x, y) {
   const hp = game.rollScaledEnemyHealth(game.config.enemy.ghostHpMin, game.config.enemy.ghostHpMax);
+  const speed = 85 + Math.random() * 35;
   return {
     type: "ghost",
     x,
     y,
     size: 20,
-    speed: 85 + Math.random() * 35,
+    speed,
     hp,
     maxHp: hp,
+    baseMaxHp: hp,
+    baseSpeed: speed,
     hpBarTimer: 0,
     damageMin: game.config.enemy.ghostDamageMin,
-    damageMax: game.config.enemy.ghostDamageMax
+    damageMax: game.config.enemy.ghostDamageMax,
+    baseDamageMin: game.config.enemy.ghostDamageMin,
+    baseDamageMax: game.config.enemy.ghostDamageMax,
+    contactAttackCooldown: 0
   };
 }
 
@@ -135,10 +174,15 @@ export function spawnSkeletonWarrior(game, x, y) {
     speed: game.config.enemy.skeletonWarriorSpeed,
     hp,
     maxHp: hp,
+    baseMaxHp: hp,
+    baseSpeed: game.config.enemy.skeletonWarriorSpeed,
     hpBarTimer: 0,
     damageMin: game.config.enemy.skeletonWarriorDamageMin,
     damageMax: game.config.enemy.skeletonWarriorDamageMax,
+    baseDamageMin: game.config.enemy.skeletonWarriorDamageMin,
+    baseDamageMax: game.config.enemy.skeletonWarriorDamageMax,
     attackCooldown: 0,
+    contactAttackCooldown: 0,
     collapsed: false,
     collapseTimer: 0,
     reviveAtEnd: false
@@ -297,9 +341,13 @@ export function applyGoblinGrowth(game, goblin, goldAmount) {
 }
 
 export function updateGoblin(game, enemy, dt, speedScale) {
+  if (isFriendlyToPlayer(game, enemy) && typeof game.getPlayerMoveSpeed === "function") {
+    enemy.speed = Math.max(Number.isFinite(enemy.speed) ? enemy.speed : 0, game.getPlayerMoveSpeed() * 1.1);
+  }
   const isStrong = enemy.goldEaten >= game.config.enemy.goblinStrongGoldThreshold;
-  const toPlayerX = game.player.x - enemy.x;
-  const toPlayerY = game.player.y - enemy.y;
+  const threat = getPriorityTarget(game, enemy, game.config.enemy.goblinFearRadius * 1.3);
+  const toPlayerX = threat.x - enemy.x;
+  const toPlayerY = threat.y - enemy.y;
   const playerDist = vecLength(toPlayerX, toPlayerY) || 1;
   const awayPlayerX = -toPlayerX / playerDist;
   const awayPlayerY = -toPlayerY / playerDist;
@@ -348,15 +396,19 @@ export function updateGoblin(game, enemy, dt, speedScale) {
 }
 
 export function updateMimic(game, enemy, dt, speedScale) {
+  if (isFriendlyToPlayer(game, enemy) && typeof game.getPlayerMoveSpeed === "function") {
+    enemy.speed = Math.max(Number.isFinite(enemy.speed) ? enemy.speed : 0, game.getPlayerMoveSpeed() * 1.1);
+  }
   const tile = game.config?.map?.tile || 32;
   const wakeRadius = (game.config.enemy.mimicWakeRadiusTiles || 3) * tile;
   const tongueRange = (game.config.enemy.mimicTongueRangeTiles || 2) * tile;
   const tongueCooldownMax = game.config.enemy.mimicTongueCooldown || 1.35;
   const tongueWindup = game.config.enemy.mimicTongueWindup || 0.18;
-  const toPlayerX = game.player.x - enemy.x;
-  const toPlayerY = game.player.y - enemy.y;
+  const target = getPriorityTarget(game, enemy, wakeRadius * 2.2);
+  const toPlayerX = target.x - enemy.x;
+  const toPlayerY = target.y - enemy.y;
   const playerDist = vecLength(toPlayerX, toPlayerY) || 1;
-  const seesPlayer = hasLineOfSight(game, enemy.x, enemy.y, game.player.x, game.player.y);
+  const seesPlayer = hasLineOfSight(game, enemy.x, enemy.y, target.x, target.y);
 
   enemy.tongueCooldown = Math.max(0, (enemy.tongueCooldown || 0) - dt);
   enemy.tongueTimer = Math.max(0, (enemy.tongueTimer || 0) - dt);
@@ -396,13 +448,15 @@ export function updateMimic(game, enemy, dt, speedScale) {
     enemy.tongueCooldown = tongueCooldownMax;
     enemy.tongueTimer = tongueWindup;
     enemy.tongueLength = Math.min(tongueRange, playerDist);
-    if (game.player.hitCooldown <= 0) {
+    if (target === game.player && game.player.hitCooldown <= 0) {
       game.player.hitCooldown = 1.0;
       const rawDamage = game.rollEnemyContactDamage(enemy);
       const scaledEnemyDamage = rawDamage * game.getEnemyDamageScale();
       const reducedByDefense = Math.max(1, Math.round(scaledEnemyDamage - game.getDefenseFlatReduction()));
       const damageTaken = game.getWarriorRageDamageTaken(reducedByDefense);
       game.applyPlayerDamage(damageTaken);
+    } else if (target !== game.player) {
+      game.applyEnemyDamage(target, game.rollEnemyContactDamage(enemy) * game.getEnemyDamageScale(), "physical");
     }
     return;
   }
@@ -417,14 +471,18 @@ export function updateMimic(game, enemy, dt, speedScale) {
 }
 
 export function updateRatArcher(game, enemy, dt, speedScale) {
+  if (isFriendlyToPlayer(game, enemy) && typeof game.getPlayerMoveSpeed === "function") {
+    enemy.speed = Math.max(Number.isFinite(enemy.speed) ? enemy.speed : 0, game.getPlayerMoveSpeed() * 1.1);
+  }
   const tile = game.config?.map?.tile || 32;
   const preferredRange = (game.config.enemy.ratArcherPreferredRangeTiles || 7) * tile;
   const retreatRange = (game.config.enemy.ratArcherRetreatRangeTiles || 5) * tile;
   const dodgeRadius = (game.config.enemy.ratArcherDodgeRadiusTiles || 2) * tile;
-  const toPlayerX = game.player.x - enemy.x;
-  const toPlayerY = game.player.y - enemy.y;
+  const target = getPriorityTarget(game, enemy, preferredRange * 1.8);
+  const toPlayerX = target.x - enemy.x;
+  const toPlayerY = target.y - enemy.y;
   const playerDist = vecLength(toPlayerX, toPlayerY) || 1;
-  const seesPlayer = hasLineOfSight(game, enemy.x, enemy.y, game.player.x, game.player.y);
+  const seesPlayer = hasLineOfSight(game, enemy.x, enemy.y, target.x, target.y);
   enemy.dirX = toPlayerX / playerDist;
   enemy.dirY = toPlayerY / playerDist;
   const prevWindupTimer = Number.isFinite(enemy.shotWindupTimer) ? enemy.shotWindupTimer : 0;
@@ -526,7 +584,8 @@ export function updateRatArcher(game, enemy, dt, speedScale) {
   }
 
   if (playerDist > preferredRange || !seesPlayer) {
-    game.moveEnemyTowardPlayer(enemy, speedScale, dt);
+    if (typeof game.moveEnemyTowardTarget === "function") game.moveEnemyTowardTarget(enemy, target, speedScale, dt, 6);
+    else game.moveEnemyTowardPlayer(enemy, speedScale, dt);
     return;
   }
 
@@ -536,6 +595,9 @@ export function updateRatArcher(game, enemy, dt, speedScale) {
 }
 
 export function updateSkeletonWarrior(game, enemy, dt, speedScale) {
+  if (isFriendlyToPlayer(game, enemy) && typeof game.getPlayerMoveSpeed === "function") {
+    enemy.speed = Math.max(Number.isFinite(enemy.speed) ? enemy.speed : 0, game.getPlayerMoveSpeed() * 1.1);
+  }
   enemy.attackCooldown = Math.max(0, (enemy.attackCooldown || 0) - dt);
   if (enemy.collapsed) {
     enemy.collapseTimer = Math.max(0, (enemy.collapseTimer || 0) - dt);
@@ -551,24 +613,28 @@ export function updateSkeletonWarrior(game, enemy, dt, speedScale) {
     return;
   }
   const range = game.config.enemy.skeletonWarriorAttackRange || 42;
-  const dx = game.player.x - enemy.x;
-  const dy = game.player.y - enemy.y;
+  const target = getPriorityTarget(game, enemy, range * 4);
+  const dx = target.x - enemy.x;
+  const dy = target.y - enemy.y;
   const dist = vecLength(dx, dy) || 1;
   enemy.dirX = dx / dist;
   enemy.dirY = dy / dist;
   if (dist <= range && enemy.attackCooldown <= 0) {
     enemy.attackCooldown = game.config.enemy.skeletonWarriorAttackCooldown || 1.0;
-    if (game.player.hitCooldown <= 0) {
+    if (target === game.player && game.player.hitCooldown <= 0) {
       game.player.hitCooldown = 1.0;
       const rawDamage = game.rollEnemyContactDamage(enemy);
       const scaledEnemyDamage = rawDamage * game.getEnemyDamageScale();
       const reducedByDefense = Math.max(1, Math.round(scaledEnemyDamage - game.getDefenseFlatReduction()));
       const damageTaken = game.getWarriorRageDamageTaken(reducedByDefense);
       game.applyPlayerDamage(damageTaken);
+    } else if (target !== game.player) {
+      game.applyEnemyDamage(target, game.rollEnemyContactDamage(enemy) * game.getEnemyDamageScale(), "physical");
     }
     return;
   }
-  game.moveEnemyTowardPlayer(enemy, speedScale, dt);
+  if (typeof game.moveEnemyTowardTarget === "function") game.moveEnemyTowardTarget(enemy, target, speedScale, dt, 6);
+  else game.moveEnemyTowardPlayer(enemy, speedScale, dt);
 }
 
 export function updateNecromancer(game, enemy, dt, speedScale) {

--- a/src/game/gameStep.js
+++ b/src/game/gameStep.js
@@ -29,6 +29,22 @@ export function stepGame(game, dt, controls = {}) {
       t0 <= t1
     );
   };
+  const beamHasLineOfSight = (x0, y0, x1, y1) => {
+    const dx = x1 - x0;
+    const dy = y1 - y0;
+    const dist = vecLength(dx, dy);
+    if (dist <= 1) return true;
+    const tile = game.config?.map?.tile || 32;
+    const step = Math.max(8, tile * 0.35);
+    const steps = Math.max(1, Math.ceil(dist / step));
+    for (let i = 1; i < steps; i++) {
+      const t = i / steps;
+      const sx = x0 + dx * t;
+      const sy = y0 + dy * t;
+      if (game.isWallAt(sx, sy, false)) return false;
+    }
+    return true;
+  };
   if (controls.processUi !== false && typeof game.handleUiClicks === "function") {
     game.handleUiClicks();
   }
@@ -40,6 +56,7 @@ export function stepGame(game, dt, controls = {}) {
   game.player.speed = game.getPlayerMoveSpeed();
   game.player.fireCooldown = Math.max(0, game.player.fireCooldown - dt);
   game.player.fireArrowCooldown = Math.max(0, game.player.fireArrowCooldown - dt);
+  game.player.deathBoltCooldown = Math.max(0, (Number.isFinite(game.player.deathBoltCooldown) ? game.player.deathBoltCooldown : 0) - dt);
   game.player.hitCooldown = Math.max(0, game.player.hitCooldown - dt);
   game.player.hpBarTimer = Math.max(0, game.player.hpBarTimer - dt);
   game.warriorMomentumTimer = Math.max(0, game.warriorMomentumTimer - dt);
@@ -129,8 +146,141 @@ export function stepGame(game, dt, controls = {}) {
     }
   }
 
-  if (controls.firePrimaryQueued) game.fire(game.player.dirX, game.player.dirY);
-  if (controls.firePrimaryHeld && controls.hasAim) game.fire(game.player.dirX, game.player.dirY);
+  if (game.isNecromancerClass && game.isNecromancerClass()) {
+    const beam = game.necromancerBeam || (game.necromancerBeam = {
+      active: false,
+      targetId: null,
+      targetX: 0,
+      targetY: 0,
+      progress: 0,
+      healTickTimer: 0,
+      targetEnemy: null
+    });
+    const beamRange = (game.config.necromancer?.controlRangeTiles || 10) * game.config.map.tile;
+    const beamWidth = Number.isFinite(game.config.necromancer?.beamWidth) ? game.config.necromancer.beamWidth : 11;
+    const held = !!controls.firePrimaryHeld && !!controls.hasAim;
+    if (!beam.failLatch) beam.failLatch = false;
+    beam.active = held;
+    beam.targetId = null;
+    beam.targetEnemy = null;
+    beam.targetX = controls.aimX;
+    beam.targetY = controls.aimY;
+    if (held) {
+      const aimLen = vecLength(controls.aimX - game.player.x, controls.aimY - game.player.y);
+      const hitBreakable = (() => {
+        let best = null;
+        let bestDist = Number.POSITIVE_INFINITY;
+        for (const br of game.breakables || []) {
+          if (!br || (br.hp || 0) <= 0) continue;
+          const beamDist = vecLength(br.x - game.player.x, br.y - game.player.y);
+          if (beamDist > beamRange) continue;
+          if (!beamHasLineOfSight(game.player.x, game.player.y, br.x, br.y)) continue;
+          const lineDist = Math.abs((controls.aimY - game.player.y) * br.x - (controls.aimX - game.player.x) * br.y + controls.aimX * game.player.y - controls.aimY * game.player.x) /
+            Math.max(1, aimLen);
+          if (lineDist > beamWidth + (br.size || 20) * 0.35) continue;
+          const distToAim = vecLength(br.x - controls.aimX, br.y - controls.aimY);
+          if (distToAim < bestDist) {
+            best = br;
+            bestDist = distToAim;
+          }
+        }
+        return best;
+      })();
+      if (hitBreakable) {
+        beam.targetX = hitBreakable.x;
+        beam.targetY = hitBreakable.y;
+        beam.progress = 0;
+        beam.healTickTimer = 0;
+        hitBreakable.hp = 0;
+        beam.failLatch = false;
+      }
+      const invalidTarget = (() => {
+        let best = null;
+        let bestDist = Number.POSITIVE_INFINITY;
+        for (const enemy of game.enemies) {
+          if (!enemy || (enemy.hp || 0) <= 0) continue;
+          if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
+          const beamDist = vecLength(enemy.x - game.player.x, enemy.y - game.player.y);
+          if (beamDist > beamRange) continue;
+          if (!beamHasLineOfSight(game.player.x, game.player.y, enemy.x, enemy.y)) continue;
+          const lineDist = Math.abs((controls.aimY - game.player.y) * enemy.x - (controls.aimX - game.player.x) * enemy.y + controls.aimX * game.player.y - controls.aimY * game.player.x) /
+            Math.max(1, aimLen);
+          if (lineDist > beamWidth) continue;
+          const distToAim = vecLength(enemy.x - controls.aimX, enemy.y - controls.aimY);
+          if (distToAim < bestDist) {
+            best = enemy;
+            bestDist = distToAim;
+          }
+        }
+        return best;
+      })();
+      if (!hitBreakable && invalidTarget && (!game.isUndeadEnemy(invalidTarget) || (!game.isControlledUndead(invalidTarget) && !game.canControlMoreUndead()))) {
+        beam.active = false;
+        beam.progress = 0;
+        beam.healTickTimer = 0;
+        if (!beam.failLatch) {
+          game.spawnFloatingText(controls.aimX, controls.aimY - 10, "Fail!", "#ef5b5b", 0.7, 15);
+          beam.failLatch = true;
+        }
+      } else {
+        beam.failLatch = false;
+      }
+    } else {
+      beam.failLatch = false;
+    }
+    if (beam.active) {
+      let bestTarget = null;
+      let bestDist = Number.POSITIVE_INFINITY;
+      for (const enemy of game.enemies) {
+        if (!game.isUndeadEnemy(enemy) || (enemy.hp || 0) <= 0) continue;
+        if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
+        const beamDist = vecLength(enemy.x - game.player.x, enemy.y - game.player.y);
+        if (beamDist > beamRange) continue;
+        if (!beamHasLineOfSight(game.player.x, game.player.y, enemy.x, enemy.y)) continue;
+        const lineDist = Math.abs((controls.aimY - game.player.y) * enemy.x - (controls.aimX - game.player.x) * enemy.y + controls.aimX * game.player.y - controls.aimY * game.player.x) /
+          Math.max(1, vecLength(controls.aimX - game.player.x, controls.aimY - game.player.y));
+        if (lineDist > beamWidth) continue;
+        const distToAim = vecLength(enemy.x - controls.aimX, enemy.y - controls.aimY);
+        if (distToAim < bestDist) {
+          bestDist = distToAim;
+          bestTarget = enemy;
+        }
+      }
+      if (bestTarget) {
+        beam.targetId = bestTarget.id || null;
+        beam.targetEnemy = bestTarget;
+        beam.targetX = bestTarget.x;
+        beam.targetY = bestTarget.y;
+        if (game.isControlledUndead(bestTarget)) {
+          beam.progress = 0;
+          beam.healTickTimer = (beam.healTickTimer || 0) + dt;
+          const healPeriod = game.config.necromancer?.healTickSeconds || 0.2;
+          while (beam.healTickTimer >= healPeriod) {
+            beam.healTickTimer -= healPeriod;
+            game.healControlledUndead(bestTarget, game.getNecroticBeamHealAmount());
+          }
+        } else {
+          beam.healTickTimer = 0;
+          beam.progress += dt;
+          if (beam.progress >= game.getNecromancerCharmDuration()) {
+            if (game.markUndeadAsControlled(bestTarget)) {
+              beam.progress = 0;
+              game.spawnFloatingText(bestTarget.x, bestTarget.y - bestTarget.size * 0.7, "Charmed", "#8eb8ff", 0.9, 14);
+            }
+          }
+        }
+      } else {
+        beam.progress = 0;
+        beam.healTickTimer = 0;
+      }
+    } else {
+      beam.progress = 0;
+      beam.healTickTimer = 0;
+    }
+  } else {
+    if (controls.firePrimaryQueued) game.fire(game.player.dirX, game.player.dirY);
+    if (controls.firePrimaryHeld && controls.hasAim) game.fire(game.player.dirX, game.player.dirY);
+  }
   if (controls.fireAltQueued) game.fireFireArrow(game.player.dirX, game.player.dirY);
 
   const activeBounds = game.getActiveBounds ? game.getActiveBounds(8) : null;
@@ -206,6 +356,7 @@ export function stepGame(game, dt, controls = {}) {
     enemy.lastY = enemy.y;
     enemy.hpBarTimer = Math.max(0, (enemy.hpBarTimer || 0) - dt);
     enemy.damageTextTimer = Math.max(0, (enemy.damageTextTimer || 0) - dt);
+    enemy.damageBuffTimer = Math.max(0, (enemy.damageBuffTimer || 0) - dt);
     if (!isActive(enemy, 72)) continue;
     activeEnemies.push(enemy);
     if (enemy.type === "goblin") game.updateGoblin(enemy, dt, enemySpeedScale);
@@ -213,6 +364,7 @@ export function stepGame(game, dt, controls = {}) {
     else if (enemy.type === "rat_archer") game.updateRatArcher(enemy, dt, enemySpeedScale);
     else if (enemy.type === "skeleton_warrior") game.updateSkeletonWarrior(enemy, dt, enemySpeedScale);
     else if (enemy.type === "necromancer") game.updateNecromancer(enemy, dt, enemySpeedScale);
+    else if (typeof game.updateGenericEnemy === "function") game.updateGenericEnemy(enemy, dt, enemySpeedScale);
     else game.moveEnemyTowardPlayer(enemy, enemySpeedScale, dt);
   }
   for (const br of game.breakables || []) {
@@ -220,6 +372,7 @@ export function stepGame(game, dt, controls = {}) {
     activeBreakables.push(br);
   }
   for (const enemy of activeEnemies) {
+    if (game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy)) continue;
     if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
     if (typeof game.separateEnemyFromPlayer === "function") game.separateEnemyFromPlayer(enemy);
   }
@@ -270,6 +423,12 @@ export function stepGame(game, dt, controls = {}) {
   for (const z of game.fireZones) z.life -= dt;
   for (const s of game.meleeSwings) s.life -= dt;
 
+  for (const bullet of game.bullets) {
+    if (bullet.projectileType === "deathBolt" && bullet.life > 0 && game.isWallAt(bullet.x, bullet.y, false)) {
+      game.triggerDeathBoltExplosion(bullet.x, bullet.y);
+      bullet.life = 0;
+    }
+  }
   game.bullets = game.bullets.filter((b) => !game.isWallAt(b.x, b.y, false) && b.life > 0);
   for (const arrow of game.fireArrows) {
     if (arrow.life <= 0 || game.isWallAt(arrow.x, arrow.y, false)) {
@@ -285,12 +444,48 @@ export function stepGame(game, dt, controls = {}) {
   for (const b of game.bullets) {
     if (b.life <= 0) continue;
     if (b.projectileType === "ratArrow") {
+      let ratArrowHit = false;
+      for (const enemy of activeEnemies) {
+        if (!game.isEnemyFriendlyToPlayer || !game.isEnemyFriendlyToPlayer(enemy)) continue;
+        if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
+        if (vecLength(b.x - enemy.x, b.y - enemy.y) <= (enemy.size + b.size) * 0.5) {
+          const rawDamage = game.rollEnemyContactDamage({ damageMin: b.damageMin, damageMax: b.damageMax });
+          game.applyEnemyDamage(enemy, rawDamage * game.getEnemyDamageScale(), "arrow");
+          b.life = 0;
+          ratArrowHit = true;
+          break;
+        }
+      }
+      if (ratArrowHit) continue;
       if (vecLength(b.x - game.player.x, b.y - game.player.y) <= playerEnemyRadius + b.size * 0.5) {
         const rawDamage = game.rollEnemyContactDamage({ damageMin: b.damageMin, damageMax: b.damageMax });
         const scaledEnemyDamage = rawDamage * game.getEnemyDamageScale();
         const reducedByDefense = Math.max(1, Math.round(scaledEnemyDamage - game.getDefenseFlatReduction()));
         const damageTaken = game.getWarriorRageDamageTaken(reducedByDefense);
         game.applyPlayerDamage(damageTaken);
+        b.life = 0;
+      }
+      continue;
+    }
+    if (b.projectileType === "deathBolt") {
+      let hit = false;
+      for (const br of activeBreakables) {
+        if (vecLength(b.x - br.x, b.y - br.y) < (br.size + b.size) * 0.45) {
+          br.hp = 0;
+          hit = true;
+          break;
+        }
+      }
+      if (!hit) {
+        for (const enemy of activeEnemies) {
+          if (vecLength(b.x - enemy.x, b.y - enemy.y) < (enemy.size + b.size) * 0.5) {
+            hit = true;
+            break;
+          }
+        }
+      }
+      if (hit) {
+        game.triggerDeathBoltExplosion(b.x, b.y);
         b.life = 0;
       }
       continue;
@@ -330,6 +525,17 @@ export function stepGame(game, dt, controls = {}) {
     }
     if (!b.hitTargets) b.hitTargets = new Set();
     if (b.faction === "enemy") {
+      for (const enemy of activeEnemies) {
+        if (!game.isEnemyFriendlyToPlayer || !game.isEnemyFriendlyToPlayer(enemy)) continue;
+        if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
+        if (vecLength(b.x - enemy.x, b.y - enemy.y) < (enemy.size + b.size) * 0.5) {
+          const rawDamage = Number.isFinite(b.damage) ? b.damage : game.config.enemy.necromancerProjectileDamage || 16;
+          game.applyEnemyDamage(enemy, rawDamage * game.getEnemyDamageScale(), b.damageType || "necrotic");
+          b.life = 0;
+          break;
+        }
+      }
+      if (b.life <= 0) continue;
       if (vecLength(b.x - game.player.x, b.y - game.player.y) < (game.player.size + b.size) * 0.5) {
         const rawDamage = Number.isFinite(b.damage) ? b.damage : game.config.enemy.necromancerProjectileDamage || 16;
         const scaledEnemyDamage = rawDamage * game.getEnemyDamageScale();
@@ -351,6 +557,7 @@ export function stepGame(game, dt, controls = {}) {
     }
     if (b.life <= 0) continue;
     for (const enemy of activeEnemies) {
+      if (game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy)) continue;
       if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
       if (b.hitTargets.has(enemy)) continue;
       if (vecLength(b.x - enemy.x, b.y - enemy.y) < (enemy.size + b.size) * 0.5) {
@@ -383,6 +590,7 @@ export function stepGame(game, dt, controls = {}) {
       continue;
     }
     for (const enemy of activeEnemies) {
+      if (game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy)) continue;
       if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
       if (vecLength(arrow.x - enemy.x, arrow.y - enemy.y) < (enemy.size + arrow.size) * 0.5) {
         if (skeletonIgnoresArrow(enemy)) continue;
@@ -399,10 +607,20 @@ export function stepGame(game, dt, controls = {}) {
 
   for (const zone of game.fireZones) {
     if (!isActive(zone, zone.radius || 0)) continue;
+    if (zone.zoneType === "deathBolt") {
+      zone.pulseTimer = Math.max(-4, (Number.isFinite(zone.pulseTimer) ? zone.pulseTimer : (game.config.deathBolt?.pulseInterval || 1)) - dt);
+      while (zone.life > 0 && zone.pulseTimer <= 0) {
+        if (typeof game.applyDeathBoltPulse === "function") game.applyDeathBoltPulse(zone.x, zone.y);
+        zone.pulseTimer += game.config.deathBolt?.pulseInterval || 1;
+      }
+      continue;
+    }
+    if (zone.zoneType && zone.zoneType !== "fire") continue;
     for (const br of activeBreakables) {
       if (vecLength(zone.x - br.x, zone.y - br.y) < zone.radius + br.size * 0.32) br.hp = 0;
     }
     for (const enemy of activeEnemies) {
+      if (game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy)) continue;
       if (enemy.type === "skeleton_warrior" && enemy.collapsed) {
         if (vecLength(zone.x - enemy.x, zone.y - enemy.y) < zone.radius + enemy.size * 0.35) {
           enemy.reviveAtEnd = false;
@@ -417,12 +635,72 @@ export function stepGame(game, dt, controls = {}) {
     }
   }
 
+  for (const enemy of activeEnemies) {
+    enemy.contactAttackCooldown = Math.max(0, (enemy.contactAttackCooldown || 0) - dt);
+  }
+  for (let i = 0; i < activeEnemies.length; i++) {
+    const a = activeEnemies[i];
+    if ((a.hp || 0) <= 0 || (a.type === "skeleton_warrior" && a.collapsed)) continue;
+    for (let j = i + 1; j < activeEnemies.length; j++) {
+      const b = activeEnemies[j];
+      if ((b.hp || 0) <= 0 || (b.type === "skeleton_warrior" && b.collapsed)) continue;
+      const aFriendly = game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(a);
+      const bFriendly = game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(b);
+      if (aFriendly === bFriendly) continue;
+      if ((aFriendly && game.necromancerBeam?.active && game.necromancerBeam.targetEnemy === b) || (bFriendly && game.necromancerBeam?.active && game.necromancerBeam.targetEnemy === a)) {
+        continue;
+      }
+      const minDist = (a.size || 20) * 0.5 + (b.size || 20) * 0.5 + 6;
+      if (vecLength(a.x - b.x, a.y - b.y) > minDist) continue;
+      const friendly = aFriendly ? a : b;
+      const hostile = aFriendly ? b : a;
+      if ((friendly.contactAttackCooldown || 0) <= 0) {
+        game.applyEnemyDamage(hostile, game.rollEnemyContactDamage(friendly) * game.getEnemyDamageScale(), "physical");
+        friendly.contactAttackCooldown = 0.55;
+      }
+      if ((hostile.contactAttackCooldown || 0) <= 0) {
+        game.applyEnemyDamage(friendly, game.rollEnemyContactDamage(hostile) * game.getEnemyDamageScale(), "physical");
+        hostile.contactAttackCooldown = 0.55;
+      }
+    }
+  }
+
+  const friendlyEnemies = activeEnemies.filter((enemy) => game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy) && (enemy.hp || 0) > 0);
+  for (let i = 0; i < friendlyEnemies.length; i++) {
+    const a = friendlyEnemies[i];
+    for (let j = i + 1; j < friendlyEnemies.length; j++) {
+      const b = friendlyEnemies[j];
+      const minDist = (a.size || 20) * 0.45 + (b.size || 20) * 0.45 + 8;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = vecLength(dx, dy) || 0.001;
+      if (dist >= minDist) continue;
+      const push = (minDist - dist) * 0.5;
+      const nx = dx / dist;
+      const ny = dy / dist;
+      game.moveWithCollision(a, -nx * push, -ny * push);
+      game.moveWithCollision(b, nx * push, ny * push);
+    }
+  }
+
+  const maxPetDistance = game.config.map.tile * 30;
+  for (const enemy of game.enemies) {
+    if (!(game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy))) continue;
+    if ((enemy.hp || 0) <= 0) continue;
+    if (vecLength(enemy.x - game.player.x, enemy.y - game.player.y) > maxPetDistance) {
+      enemy.hp = 0;
+    }
+  }
+
   let removeBossSummons = false;
   game.enemies = game.enemies.filter((enemy) => {
     if (enemy.type === "skeleton_warrior" && enemy.collapsed && enemy.collapseTimer > 0) {
       return true;
     }
     if (enemy.hp <= 0) {
+      const wasFriendly = game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy);
+      if (wasFriendly && typeof game.triggerExplodingDeath === "function") game.triggerExplodingDeath(enemy);
+      if (wasFriendly) return false;
       game.triggerWarriorMomentumOnKill();
       if (enemy.type === "goblin") game.score += 30 + enemy.goldEaten;
       else if (enemy.type === "armor") game.score += 40;
@@ -505,6 +783,7 @@ export function stepGame(game, dt, controls = {}) {
 
   if (game.player.hitCooldown <= 0) {
     for (const enemy of activeEnemies) {
+      if (game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy)) continue;
       if (enemy.type === "skeleton_warrior" && enemy.collapsed) continue;
       if (vecLength(game.player.x - enemy.x, game.player.y - enemy.y) <= enemy.size * 0.5 + playerEnemyRadius) {
         game.player.hitCooldown = 1.0;

--- a/src/game/runtimeBaseDifficultyMethods.js
+++ b/src/game/runtimeBaseDifficultyMethods.js
@@ -92,7 +92,10 @@ export const runtimeBaseDifficultyMethods = {
       : Number.isFinite(enemy?.damage)
       ? enemy.damage
       : min;
-    return { min: Math.min(min, max), max: Math.max(min, max) };
+    const multiplier = enemy?.isControlledUndead && Number.isFinite(enemy?.damageBuffMultiplier) && (enemy?.damageBuffTimer || 0) > 0
+      ? Math.max(0.1, enemy.damageBuffMultiplier)
+      : 1;
+    return { min: Math.min(min, max) * multiplier, max: Math.max(min, max) * multiplier };
   },
 
   rollEnemyContactDamage(enemy) {

--- a/src/game/world/spawnCombat.js
+++ b/src/game/world/spawnCombat.js
@@ -99,14 +99,14 @@ export function applyEnemyDamage(game, enemy, amount, damageType = "physical") {
     enemy.dormant = false;
     enemy.revealed = true;
   }
-  const defense = game.getEnemyDefenseScale();
+  const defense = game.getEnemyDefenseScale() * (Number.isFinite(enemy?.controlledDefenseMultiplier) ? Math.max(0.1, enemy.controlledDefenseMultiplier) : 1);
   if (!Number.isFinite(defense) || defense <= 0) return;
   const effective = adjusted / defense;
   if (!Number.isFinite(effective) || effective <= 0) return;
   const enemyHpBefore = Number.isFinite(enemy.hp) ? Math.max(0, enemy.hp) : 0;
   const dealt = Math.min(effective, enemyHpBefore);
   enemy.hp -= effective;
-  const lifeLeech = game.getLifeLeechPercent();
+  const lifeLeech = game.isEnemyFriendlyToPlayer && game.isEnemyFriendlyToPlayer(enemy) ? 0 : game.getLifeLeechPercent();
   if (lifeLeech > 0 && dealt > 0) {
     game.applyPlayerHealing(Math.max(1, Math.ceil(dealt * lifeLeech)));
   }
@@ -116,6 +116,13 @@ export function applyEnemyDamage(game, enemy, amount, damageType = "physical") {
     enemy.damageTextTimer = 0.14;
   }
   if (enemy?.type === "skeleton_warrior" && enemy.hp <= 0) {
+    if (game.isControlledUndead && game.isControlledUndead(enemy)) {
+      enemy.hp = 0;
+      enemy.collapsed = false;
+      enemy.collapseTimer = 0;
+      enemy.reviveAtEnd = false;
+      return;
+    }
     if (damageType === "fire") {
       enemy.reviveAtEnd = false;
       enemy.collapseTimer = 0;

--- a/src/game/world/uiEconomy.js
+++ b/src/game/world/uiEconomy.js
@@ -176,6 +176,18 @@ export function handleUiClicks(game) {
       game.spendSkillPoint("warriorExecute");
       continue;
     }
+    if (pointInRect(game, click.x, click.y, game.uiRects.skillUndeadMasteryNode)) {
+      game.spendSkillPoint("undeadMastery");
+      continue;
+    }
+    if (pointInRect(game, click.x, click.y, game.uiRects.skillDeathBoltNode)) {
+      game.spendSkillPoint("deathBolt");
+      continue;
+    }
+    if (pointInRect(game, click.x, click.y, game.uiRects.skillExplodingDeathNode)) {
+      game.spendSkillPoint("explodingDeath");
+      continue;
+    }
     const itemRects = game.uiRects.shopItems || [];
     for (const item of itemRects) {
       if (pointInRect(game, click.x, click.y, item.rect)) {

--- a/src/net/sessionInteraction.js
+++ b/src/net/sessionInteraction.js
@@ -110,6 +110,18 @@ export function handleNetworkUiActions(game, netClient, isController) {
       netClient.sendAction({ kind: "spendSkill", key: "warriorExecute" });
       continue;
     }
+    if (hit(click.x, click.y, game.uiRects.skillUndeadMasteryNode)) {
+      netClient.sendAction({ kind: "spendSkill", key: "undeadMastery" });
+      continue;
+    }
+    if (hit(click.x, click.y, game.uiRects.skillDeathBoltNode)) {
+      netClient.sendAction({ kind: "spendSkill", key: "deathBolt" });
+      continue;
+    }
+    if (hit(click.x, click.y, game.uiRects.skillExplodingDeathNode)) {
+      netClient.sendAction({ kind: "spendSkill", key: "explodingDeath" });
+      continue;
+    }
     if (hit(click.x, click.y, game.uiRects.returnMenuButton)) {
       if (typeof game.onReturnToMenu === "function") game.onReturnToMenu();
     }
@@ -172,7 +184,7 @@ export function updateNetworkRole(game, isController, networkTakeControl) {
 }
 
 export function setSelectedClass(classType, classButtons) {
-  const selectedClass = classType === "fighter" || classType === "warrior" ? "fighter" : "archer";
+  const selectedClass = classType === "fighter" || classType === "warrior" ? "fighter" : classType === "necromancer" ? "necromancer" : "archer";
   for (const button of classButtons || []) {
     const option = button.dataset.classOption === "warrior" ? "fighter" : button.dataset.classOption;
     const isActive = option === selectedClass;

--- a/src/rendering/RendererRuntimeEffects.js
+++ b/src/rendering/RendererRuntimeEffects.js
@@ -7,6 +7,29 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
       this.drawMeleeSwing(swing, cameraX, cameraY, game.player);
     }
 
+    if (game.necromancerBeam?.active) {
+      const beam = game.necromancerBeam;
+      const sx = game.player.x - cameraX;
+      const sy = game.player.y - cameraY - 8;
+      const tx = (Number.isFinite(beam.targetX) ? beam.targetX : game.player.x) - cameraX;
+      const ty = (Number.isFinite(beam.targetY) ? beam.targetY : game.player.y) - cameraY;
+      const grad = ctx.createLinearGradient(sx, sy, tx, ty);
+      grad.addColorStop(0, "rgba(112, 255, 170, 0.2)");
+      grad.addColorStop(0.5, "rgba(121, 255, 141, 0.85)");
+      grad.addColorStop(1, "rgba(185, 255, 218, 0.35)");
+      ctx.strokeStyle = grad;
+      ctx.lineWidth = 5;
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(sx, sy);
+      ctx.lineTo(tx, ty);
+      ctx.stroke();
+      if (beam.progress > 0) {
+        ctx.fillStyle = "rgba(158, 255, 186, 0.95)";
+        ctx.fillRect(tx - 12, ty - 20, 24 * Math.max(0, Math.min(1, beam.progress / (game.config.necromancer?.charmDuration || 2))), 4);
+      }
+    }
+
     for (const b of game.bullets) {
       if (b.kind === "necroticBolt") {
         this.drawNecroticBolt(b, cameraX, cameraY, game.time);
@@ -15,18 +38,30 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
       const x = b.x - cameraX;
       const y = b.y - cameraY;
       const isTrapArrow = b.projectileType === "trapArrow";
+      const isDeathBolt = b.projectileType === "deathBolt";
       ctx.save();
       ctx.translate(x, y);
       ctx.rotate(b.angle);
-      ctx.fillStyle = isTrapArrow ? "#d66e57" : "#d9c27f";
-      ctx.fillRect(-7, -1.3, 11, 2.6);
-      ctx.fillStyle = isTrapArrow ? "#ffb9a7" : "#e5e2dc";
-      ctx.beginPath();
-      ctx.moveTo(5, 0);
-      ctx.lineTo(1, -3);
-      ctx.lineTo(1, 3);
-      ctx.closePath();
-      ctx.fill();
+      if (isDeathBolt) {
+        const orb = ctx.createRadialGradient(0, 0, 1, 0, 0, 10);
+        orb.addColorStop(0, "rgba(203, 255, 205, 0.95)");
+        orb.addColorStop(0.45, "rgba(91, 230, 151, 0.9)");
+        orb.addColorStop(1, "rgba(31, 94, 58, 0.2)");
+        ctx.fillStyle = orb;
+        ctx.beginPath();
+        ctx.arc(0, 0, 9, 0, Math.PI * 2);
+        ctx.fill();
+      } else {
+        ctx.fillStyle = isTrapArrow ? "#d66e57" : "#d9c27f";
+        ctx.fillRect(-7, -1.3, 11, 2.6);
+        ctx.fillStyle = isTrapArrow ? "#ffb9a7" : "#e5e2dc";
+        ctx.beginPath();
+        ctx.moveTo(5, 0);
+        ctx.lineTo(1, -3);
+        ctx.lineTo(1, 3);
+        ctx.closePath();
+        ctx.fill();
+      }
       if (isTrapArrow) {
         ctx.fillStyle = "#791d15";
         ctx.beginPath();
@@ -161,6 +196,18 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
     const ctx = this.ctx;
     const x = zone.x - cameraX;
     const y = zone.y - cameraY;
+    if (zone.zoneType === "deathBolt" || zone.zoneType === "deathBurst") {
+      const lifeFrac = Math.max(0, Math.min(1, zone.life / (this.config.deathBolt?.visualLife || 0.35)));
+      const outer = ctx.createRadialGradient(x, y, 2, x, y, zone.radius);
+      outer.addColorStop(0, `rgba(190, 255, 210, ${0.38 * lifeFrac})`);
+      outer.addColorStop(0.5, `rgba(93, 220, 154, ${0.26 * lifeFrac})`);
+      outer.addColorStop(1, `rgba(32, 76, 54, ${0.06 * lifeFrac})`);
+      ctx.fillStyle = outer;
+      ctx.beginPath();
+      ctx.arc(x, y, zone.radius, 0, Math.PI * 2);
+      ctx.fill();
+      return;
+    }
     const lifeFrac = Math.max(0, Math.min(1, zone.life / this.config.fireArrow.lingerDuration));
     const pulse = 0.88 + Math.sin((time * 10 + zone.x * 0.02 + zone.y * 0.015)) * 0.09;
     const coreR = zone.radius * 0.42 * pulse;
@@ -250,7 +297,10 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
     const drawY = playerScreenY - renderSize * 0.56;
     let tintColor = null;
     let tintAlpha = 0;
-    if (!game.classSpec?.usesRanged) {
+    if (game.isNecromancerClass && game.isNecromancerClass()) {
+      tintColor = "#a6a8ad";
+      tintAlpha = 0.5;
+    } else if (!game.classSpec?.usesRanged) {
       if ((game.warriorRageActiveTimer || 0) > 0) {
         tintColor = "#ff2a2a";
         tintAlpha = 0.5;
@@ -263,7 +313,9 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
     const baseCd = game.getPlayerFireCooldown ? game.getPlayerFireCooldown() : this.config.player.baseFireCooldown;
     const firePulse = baseCd > 0 ? Math.max(0, Math.min(1, p.fireCooldown / baseCd)) : 0;
     const walkPhase = movingVisual ? p._renderAnimPhase * 0.1 : 0;
-    if (game.classSpec && !game.classSpec.usesRanged) {
+    if (game.isNecromancerClass && game.isNecromancerClass()) {
+      this.drawPlayerNecromancerRig(p, playerScreenX, playerScreenY, walkPhase, firePulse);
+    } else if (game.classSpec && !game.classSpec.usesRanged) {
       this.drawPlayerFighterRig(p, playerScreenX, playerScreenY, walkPhase, firePulse);
     } else {
       this.drawPlayerAimingRig(p, playerScreenX, playerScreenY, walkPhase, firePulse);
@@ -356,6 +408,48 @@ export class RendererRuntimeEffects extends RendererRuntimeScene {
     ctx.moveTo(crossX + px * 4.2, crossY + py * 4.2);
     ctx.lineTo(crossX - px * 4.2, crossY - py * 4.2);
     ctx.stroke();
+  }
+
+  drawPlayerNecromancerRig(player, screenX, screenY, walkPhase = 0, firePulse = 0) {
+    const ctx = this.ctx;
+    const aimAngle = Math.atan2(player.dirY || 0, player.dirX || 1);
+    const ax = Math.cos(aimAngle);
+    const ay = Math.sin(aimAngle);
+    const px = -ay;
+    const py = ax;
+    const chestX = screenX;
+    const chestY = screenY - 8 + Math.sin(walkPhase * Math.PI * 2) * 0.75;
+    const recoil = Math.max(0, Math.min(1, firePulse));
+    const rearHandX = chestX + ax * (5 - recoil * 2) - px * 2;
+    const rearHandY = chestY + ay * (5 - recoil * 2) - py * 2;
+    const frontHandX = chestX + ax * 10 + px * 1.5;
+    const frontHandY = chestY + ay * 10 + py * 1.5;
+    const staffBaseX = chestX - ax * 10;
+    const staffBaseY = chestY - ay * 10;
+    const staffTipX = chestX + ax * 20;
+    const staffTipY = chestY + ay * 20;
+
+    ctx.strokeStyle = "#6f737b";
+    ctx.lineWidth = 3.8;
+    ctx.lineCap = "round";
+    ctx.beginPath();
+    ctx.moveTo(chestX - px * 3.6, chestY - py * 3.6);
+    ctx.lineTo(rearHandX, rearHandY);
+    ctx.moveTo(chestX + px * 3.6, chestY + py * 3.6);
+    ctx.lineTo(frontHandX, frontHandY);
+    ctx.stroke();
+
+    ctx.strokeStyle = "#111317";
+    ctx.lineWidth = 3.2;
+    ctx.beginPath();
+    ctx.moveTo(staffBaseX, staffBaseY);
+    ctx.lineTo(staffTipX, staffTipY);
+    ctx.stroke();
+
+    ctx.fillStyle = "#23262b";
+    ctx.beginPath();
+    ctx.arc(staffTipX, staffTipY, 3.5, 0, Math.PI * 2);
+    ctx.fill();
   }
 
   drawPlayerHealthBar(game, cameraX, cameraY) {

--- a/src/rendering/RendererRuntimeScene.js
+++ b/src/rendering/RendererRuntimeScene.js
@@ -29,6 +29,9 @@ export class RendererRuntimeScene extends RendererRuntimeBase {
     game.uiRects.skillWarriorMomentumNode = null;
     game.uiRects.skillWarriorRageNode = null;
     game.uiRects.skillWarriorExecuteNode = null;
+    game.uiRects.skillUndeadMasteryNode = null;
+    game.uiRects.skillDeathBoltNode = null;
+    game.uiRects.skillExplodingDeathNode = null;
     game.uiRects.statsButton = null;
     game.uiRects.statsClose = null;
 
@@ -68,7 +71,7 @@ export class RendererRuntimeScene extends RendererRuntimeBase {
         if (enemy.dormant) this.drawBreakable({ type: "box", size: enemy.size }, enemy.x - cameraX, enemy.y - cameraY);
         else this.drawMimic(enemy, enemy.x - cameraX, enemy.y - cameraY);
       } else {
-        this.drawGhost(enemy.x - cameraX, enemy.y - cameraY, enemy.size);
+        this.drawGhost(enemy, enemy.x - cameraX, enemy.y - cameraY, enemy.size);
       }
       this.drawEnemyHealthBar(enemy, enemy.x - cameraX, enemy.y - cameraY);
     }

--- a/src/rendering/hud/menus.js
+++ b/src/rendering/hud/menus.js
@@ -158,6 +158,12 @@ export function drawSkillTreeMenu(renderer, game, layout) {
   const nextExecuteChance = game.getWarriorExecuteChance(nextExecutePoints);
   const curExecuteThreshold = game.getWarriorExecuteThreshold(executeSkill.points);
   const nextExecuteThreshold = game.getWarriorExecuteThreshold(nextExecutePoints);
+  const undeadMasterySkill = game.skills.undeadMastery;
+  const deathBoltSkill = game.skills.deathBolt;
+  const explodingDeathSkill = game.skills.explodingDeath;
+  const canSpendUndeadMastery = game.skillPoints > 0 && undeadMasterySkill.points < undeadMasterySkill.maxPoints;
+  const canSpendDeathBolt = game.skillPoints > 0 && deathBoltSkill.points < deathBoltSkill.maxPoints;
+  const canSpendExplodingDeath = game.skillPoints > 0 && explodingDeathSkill.points < explodingDeathSkill.maxPoints;
 
   ctx.fillStyle = "rgba(4, 7, 11, 0.78)";
   ctx.fillRect(0, 0, layout.playW, renderer.canvas.height);
@@ -186,7 +192,7 @@ export function drawSkillTreeMenu(renderer, game, layout) {
   const contentTop = menuY + 50;
   const contentBottom = menuY + menuH - 8;
   const visibleH = contentBottom - contentTop;
-  const contentHeight = !game.classSpec.usesRanged ? 836 : 582;
+  const contentHeight = game.isNecromancerClass && game.isNecromancerClass() ? 676 : !game.classSpec.usesRanged ? 836 : 582;
   const scrollMax = Math.max(0, contentHeight - visibleH);
   const scroll = Math.max(0, Math.min(scrollMax, game.uiScroll?.skillTree || 0));
   game.uiScroll.skillTree = scroll;
@@ -198,6 +204,89 @@ export function drawSkillTreeMenu(renderer, game, layout) {
   ctx.beginPath();
   ctx.rect(menuX + 8, contentTop, menuW - 16, visibleH);
   ctx.clip();
+
+  if (game.isNecromancerClass && game.isNecromancerClass()) {
+    const masteryCard = { x: menuX + 22, y: sy(menuY + 58), w: menuW - 44, h: 196 };
+    ctx.fillStyle = "rgba(18, 28, 45, 0.95)";
+    ctx.fillRect(masteryCard.x, masteryCard.y, masteryCard.w, masteryCard.h);
+    ctx.strokeStyle = "rgba(124, 177, 255, 0.82)";
+    ctx.strokeRect(masteryCard.x, masteryCard.y, masteryCard.w, masteryCard.h);
+    ctx.fillStyle = "#eef4ff";
+    ctx.font = "bold 18px Trebuchet MS";
+    ctx.fillText("Control Mastery", masteryCard.x + 14, masteryCard.y + 28);
+    ctx.font = "14px Trebuchet MS";
+    ctx.fillStyle = "#cad8f7";
+    ctx.fillText(`Points: ${undeadMasterySkill.points}/${undeadMasterySkill.maxPoints}`, masteryCard.x + 14, masteryCard.y + 50);
+    ctx.fillText(`Control Cap: ${game.getNecromancerControlCap()}`, masteryCard.x + 220, masteryCard.y + 50);
+    ctx.fillStyle = "#d9e6ff";
+    ctx.fillText(`Charm Time: ${game.getNecromancerCharmDuration().toFixed(2)}s`, masteryCard.x + 14, masteryCard.y + 82);
+    ctx.fillText(`Controlled Undead: ${game.getControlledUndeadCount()}/${game.getNecromancerControlCap()}`, masteryCard.x + 14, masteryCard.y + 104);
+    ctx.fillStyle = "#adc1ea";
+    ctx.fillText("Adds +1 control cap per rank and smoothly lowers charm time to 0.5s.", masteryCard.x + 14, masteryCard.y + 132);
+    const masterySpendRect = { x: masteryCard.x + masteryCard.w - 142, y: masteryCard.y + masteryCard.h - 48, w: 124, h: 34 };
+    game.uiRects.skillUndeadMasteryNode = masterySpendRect;
+    ctx.fillStyle = canSpendUndeadMastery ? "rgba(96, 145, 206, 0.95)" : "rgba(80, 76, 90, 0.95)";
+    ctx.fillRect(masterySpendRect.x, masterySpendRect.y, masterySpendRect.w, masterySpendRect.h);
+    ctx.strokeStyle = "rgba(232, 226, 211, 0.58)";
+    ctx.strokeRect(masterySpendRect.x, masterySpendRect.y, masterySpendRect.w, masterySpendRect.h);
+    ctx.fillStyle = "#f3efe3";
+    ctx.font = "bold 14px Trebuchet MS";
+    ctx.fillText("Spend 1 SP", masterySpendRect.x + 20, masterySpendRect.y + 22);
+
+    const boltCard = { x: menuX + 22, y: masteryCard.y + masteryCard.h + 12, w: menuW - 44, h: 192 };
+    ctx.fillStyle = "rgba(18, 38, 28, 0.95)";
+    ctx.fillRect(boltCard.x, boltCard.y, boltCard.w, boltCard.h);
+    ctx.strokeStyle = "rgba(116, 214, 158, 0.82)";
+    ctx.strokeRect(boltCard.x, boltCard.y, boltCard.w, boltCard.h);
+    ctx.fillStyle = "#edf8ef";
+    ctx.font = "bold 18px Trebuchet MS";
+    ctx.fillText("Death Bolt", boltCard.x + 14, boltCard.y + 28);
+    ctx.font = "14px Trebuchet MS";
+    ctx.fillStyle = "#c8efd8";
+    ctx.fillText(`Points: ${deathBoltSkill.points}/${deathBoltSkill.maxPoints}`, boltCard.x + 14, boltCard.y + 50);
+    ctx.fillText(`Cooldown: ${(game.config.deathBolt?.cooldown || 10).toFixed(1)}s`, boltCard.x + 220, boltCard.y + 50);
+    ctx.fillStyle = "#dff8e9";
+    ctx.fillText(`Damage: ${game.getDeathBoltBaseDamage().toFixed(1)} | Heal: ${game.getDeathBoltHealAmount().toFixed(1)}`, boltCard.x + 14, boltCard.y + 80);
+    ctx.fillText(`Cost: ${((game.config.deathBolt?.hpCostPct || 0.05) * 100).toFixed(0)}% HP | Radius: ${game.getDeathBoltRadius().toFixed(0)}`, boltCard.x + 14, boltCard.y + 102);
+    ctx.fillStyle = "#bce6ca";
+    ctx.fillText("Blast pulses on impact and every second for 5s. Pet damage buff starts at +25% on rank 5.", boltCard.x + 14, boltCard.y + 130);
+    const boltSpendRect = { x: boltCard.x + boltCard.w - 142, y: boltCard.y + boltCard.h - 48, w: 124, h: 34 };
+    game.uiRects.skillDeathBoltNode = boltSpendRect;
+    ctx.fillStyle = canSpendDeathBolt ? "rgba(88, 164, 120, 0.95)" : "rgba(80, 76, 90, 0.95)";
+    ctx.fillRect(boltSpendRect.x, boltSpendRect.y, boltSpendRect.w, boltSpendRect.h);
+    ctx.strokeStyle = "rgba(232, 226, 211, 0.58)";
+    ctx.strokeRect(boltSpendRect.x, boltSpendRect.y, boltSpendRect.w, boltSpendRect.h);
+    ctx.fillStyle = "#f3efe3";
+    ctx.font = "bold 14px Trebuchet MS";
+    ctx.fillText("Spend 1 SP", boltSpendRect.x + 20, boltSpendRect.y + 22);
+
+    const explodeCard = { x: menuX + 22, y: boltCard.y + boltCard.h + 12, w: menuW - 44, h: 156 };
+    ctx.fillStyle = "rgba(22, 28, 38, 0.95)";
+    ctx.fillRect(explodeCard.x, explodeCard.y, explodeCard.w, explodeCard.h);
+    ctx.strokeStyle = "rgba(151, 210, 255, 0.8)";
+    ctx.strokeRect(explodeCard.x, explodeCard.y, explodeCard.w, explodeCard.h);
+    ctx.fillStyle = "#eef6ff";
+    ctx.font = "bold 18px Trebuchet MS";
+    ctx.fillText("Augment Death", explodeCard.x + 14, explodeCard.y + 28);
+    ctx.font = "14px Trebuchet MS";
+    ctx.fillStyle = "#d7e8fb";
+    ctx.fillText(`Points: ${explodingDeathSkill.points}/${explodingDeathSkill.maxPoints}`, explodeCard.x + 14, explodeCard.y + 50);
+    ctx.fillText(`Damage: ${game.getDeathExplosionDamage().toFixed(1)}`, explodeCard.x + 220, explodeCard.y + 50);
+    ctx.fillText(`Pet Boost: +${((game.getControlledUndeadBoost() - 1) * 100).toFixed(0)}%`, explodeCard.x + 14, explodeCard.y + 80);
+    ctx.fillStyle = "#bdd8ee";
+    ctx.fillText("Pets gain stat boosts from rank 1. At rank 3, they also explode on death.", explodeCard.x + 14, explodeCard.y + 106);
+    const explodeSpendRect = { x: explodeCard.x + explodeCard.w - 142, y: explodeCard.y + explodeCard.h - 48, w: 124, h: 34 };
+    game.uiRects.skillExplodingDeathNode = explodeSpendRect;
+    ctx.fillStyle = canSpendExplodingDeath ? "rgba(97, 150, 202, 0.95)" : "rgba(80, 76, 90, 0.95)";
+    ctx.fillRect(explodeSpendRect.x, explodeSpendRect.y, explodeSpendRect.w, explodeSpendRect.h);
+    ctx.strokeStyle = "rgba(232, 226, 211, 0.58)";
+    ctx.strokeRect(explodeSpendRect.x, explodeSpendRect.y, explodeSpendRect.w, explodeSpendRect.h);
+    ctx.fillStyle = "#f3efe3";
+    ctx.font = "bold 14px Trebuchet MS";
+    ctx.fillText("Spend 1 SP", explodeSpendRect.x + 20, explodeSpendRect.y + 22);
+    ctx.restore();
+    return;
+  }
 
   if (!game.classSpec.usesRanged) {
     const card = { x: menuX + 22, y: sy(menuY + 58), w: menuW - 44, h: 208 };

--- a/src/rendering/hud/stats.js
+++ b/src/rendering/hud/stats.js
@@ -5,8 +5,14 @@ export function drawPlayerStatsPanel(renderer, game, layout, panelY) {
   const panelH = 118;
   const outpace = game.getEnemyOutpacingStatus();
   const goblinCount = game.enemies.filter((enemy) => enemy.type === "goblin").length;
-  const fireCdText = !game.classSpec.usesRanged
+  const fireCdText = game.isWarriorClass && game.isWarriorClass()
     ? "N/A"
+    : game.isNecromancerClass && game.isNecromancerClass()
+    ? game.player.deathBoltCooldown > 0
+      ? game.player.deathBoltCooldown.toFixed(1) + "s"
+      : game.skills.deathBolt.points > 0
+      ? "Ready"
+      : "Locked"
     : !game.isFireArrowUnlocked()
     ? "Locked"
     : game.player.fireArrowCooldown > 0
@@ -126,19 +132,26 @@ export function drawPlayerStatsPanel(renderer, game, layout, panelY) {
   row("Class", game.classSpec.label);
   row(
     "Range/Reach",
-    game.classSpec.usesRanged
+    game.isWarriorClass && game.isWarriorClass()
+      ? `${(game.classSpec.meleeRange || 42).toFixed(0)} melee`
+      : game.isNecromancerClass && game.isNecromancerClass()
+      ? `${((game.config.necromancer?.controlRangeTiles || 10) * game.config.map.tile).toFixed(0)} beam`
+      : game.classSpec.usesRanged
       ? `${(game.getProjectileSpeed ? game.getProjectileSpeed() : game.config.player.projectileSpeed).toFixed(0)} arrow`
       : `${(game.classSpec.meleeRange || 42).toFixed(0)} melee`
   );
-  row("Fire Arrow", game.classSpec.usesRanged ? `${game.isFireArrowUnlocked() ? `Lv ${game.skills.fireArrow.points}` : "Locked"}` : "N/A");
-  row("Fire AoE Radius", game.classSpec.usesRanged ? `${game.isFireArrowUnlocked() ? game.getFireArrowBlastRadius().toFixed(1) : "-"}` : "N/A");
-  row("Pierce Chance", game.classSpec.usesRanged ? `${(game.getPiercingChance() * 100).toFixed(1)}%` : "N/A");
-  row("Multiarrow", game.classSpec.usesRanged ? `${game.getMultiarrowCount()} (${game.getMultiarrowSpreadDeg().toFixed(1)}deg)` : "N/A");
-  row("Frenzy Skill", game.classSpec.usesRanged ? "N/A" : `Lv ${game.skills.warriorMomentum.points} (+${(game.getWarriorMomentumMoveBonus() * 100).toFixed(0)}%)`);
-  row("Frenzy", game.classSpec.usesRanged ? "N/A" : game.warriorMomentumTimer > 0 ? `${game.warriorMomentumTimer.toFixed(1)}s` : "Idle");
-  row("Rage Skill", game.classSpec.usesRanged ? "N/A" : `Lv ${game.skills.warriorRage.points} (CD ${game.getWarriorRageCooldown().toFixed(1)}s)`);
-  row("Rage", game.classSpec.usesRanged ? "N/A" : game.warriorRageActiveTimer > 0 ? `Active ${game.warriorRageActiveTimer.toFixed(1)}s` : game.warriorRageCooldownTimer > 0 ? `Cooldown ${game.warriorRageCooldownTimer.toFixed(1)}s` : "Ready");
-  row("Rage Dmg Bonus", game.classSpec.usesRanged ? "N/A" : `+${game.getWarriorRageBaseDamageBonus().toFixed(2)} base`);
+  row("Fire Arrow", game.isArcherClass && game.isArcherClass() ? `${game.isFireArrowUnlocked() ? `Lv ${game.skills.fireArrow.points}` : "Locked"}` : "N/A");
+  row("Fire AoE Radius", game.isArcherClass && game.isArcherClass() ? `${game.isFireArrowUnlocked() ? game.getFireArrowBlastRadius().toFixed(1) : "-"}` : "N/A");
+  row("Pierce Chance", game.isArcherClass && game.isArcherClass() ? `${(game.getPiercingChance() * 100).toFixed(1)}%` : "N/A");
+  row("Multiarrow", game.isArcherClass && game.isArcherClass() ? `${game.getMultiarrowCount()} (${game.getMultiarrowSpreadDeg().toFixed(1)}deg)` : "N/A");
+  row("Frenzy Skill", game.isWarriorClass && game.isWarriorClass() ? `Lv ${game.skills.warriorMomentum.points} (+${(game.getWarriorMomentumMoveBonus() * 100).toFixed(0)}%)` : "N/A");
+  row("Frenzy", game.isWarriorClass && game.isWarriorClass() ? game.warriorMomentumTimer > 0 ? `${game.warriorMomentumTimer.toFixed(1)}s` : "Idle" : "N/A");
+  row("Rage Skill", game.isWarriorClass && game.isWarriorClass() ? `Lv ${game.skills.warriorRage.points} (CD ${game.getWarriorRageCooldown().toFixed(1)}s)` : "N/A");
+  row("Rage", game.isWarriorClass && game.isWarriorClass() ? game.warriorRageActiveTimer > 0 ? `Active ${game.warriorRageActiveTimer.toFixed(1)}s` : game.warriorRageCooldownTimer > 0 ? `Cooldown ${game.warriorRageCooldownTimer.toFixed(1)}s` : "Ready" : "N/A");
+  row("Rage Dmg Bonus", game.isWarriorClass && game.isWarriorClass() ? `+${game.getWarriorRageBaseDamageBonus().toFixed(2)} base` : "N/A");
+  row("Control Mastery", game.isNecromancerClass && game.isNecromancerClass() ? `Lv ${game.skills.undeadMastery.points} (${game.getControlledUndeadCount()}/${game.getNecromancerControlCap()}, ${game.getNecromancerCharmDuration().toFixed(2)}s)` : "N/A");
+  row("Death Bolt", game.isNecromancerClass && game.isNecromancerClass() ? `Lv ${game.skills.deathBolt.points} (${game.getDeathBoltBaseDamage().toFixed(1)} dmg, +${((game.getDeathBoltPetDamageMultiplier() - 1) * 100).toFixed(0)}% pet dmg)` : "N/A");
+  row("Augment Death", game.isNecromancerClass && game.isNecromancerClass() ? `Lv ${game.skills.explodingDeath.points} (+${((game.getControlledUndeadBoost() - 1) * 100).toFixed(0)}%, ${game.skills.explodingDeath.points >= 3 ? `${game.getDeathExplosionDamage().toFixed(1)} dmg` : "inactive"})` : "N/A");
   row("Key", `${game.hasKey ? "Yes" : "No"}`);
   row("Enemy Speed", `x${game.getEnemySpeedScale().toFixed(2)}`);
   row("Enemy Damage", `x${game.getEnemyDamageScale().toFixed(2)}`);

--- a/src/rendering/hud/top.js
+++ b/src/rendering/hud/top.js
@@ -10,9 +10,13 @@ export function drawHud(renderer, game, layout) {
   ctx.fillText(`Time: ${formatTime(game.time)}`, 200, 24);
   ctx.fillText(`Floor: ${game.floor}`, 360, 24);
   ctx.fillText(`Class: ${game.classSpec?.label || "Unknown"}`, 468, 24);
+  if (game.isNecromancerClass && game.isNecromancerClass()) {
+    ctx.fillStyle = "#8fc2ff";
+    ctx.fillText(`Pets: ${game.getControlledUndeadCount()}/${game.getNecromancerControlCap()}`, 690, 24);
+  }
   if (game.networkEnabled) {
     ctx.fillStyle = game.networkRole === "Controller" ? "#8fe3a2" : "#dfc670";
-    ctx.fillText(`Net: ${game.networkRole || "Connected"}`, 690, 24);
+    ctx.fillText(`Net: ${game.networkRole || "Connected"}`, game.isNecromancerClass && game.isNecromancerClass() ? 830 : 690, 24);
   }
 
   const objective = typeof game.getFloorObjectiveText === "function" ? game.getFloorObjectiveText() : "";

--- a/src/rendering/runtimeSceneDrawMethods.js
+++ b/src/rendering/runtimeSceneDrawMethods.js
@@ -155,14 +155,18 @@ export const runtimeSceneDrawMethods = {
     }
   },
 
-  drawGhost(screenX, screenY, size) {
+  drawGhost(enemyOrScreenX, maybeScreenX, maybeScreenY, maybeSize) {
     const ctx = this.ctx;
+    const enemy = typeof enemyOrScreenX === "object" && enemyOrScreenX !== null ? enemyOrScreenX : null;
+    const screenX = enemy ? maybeScreenX : enemyOrScreenX;
+    const screenY = enemy ? maybeScreenY : maybeScreenX;
+    const size = enemy ? maybeSize : maybeScreenY;
     const half = size / 2;
     const headRadius = half * 0.58;
     const bodyTop = screenY - size * 0.12;
     const bodyBottom = screenY + half;
 
-    ctx.fillStyle = "#d8f2ff";
+    ctx.fillStyle = enemy?.isControlledUndead ? "#9eb8ff" : "#d8f2ff";
     ctx.beginPath();
     ctx.arc(screenX, screenY - size * 0.2, headRadius, Math.PI, 0);
     ctx.lineTo(screenX + half * 0.82, bodyBottom - 4);
@@ -174,7 +178,7 @@ export const runtimeSceneDrawMethods = {
     ctx.closePath();
     ctx.fill();
 
-    ctx.fillStyle = "rgba(120, 208, 255, 0.45)";
+    ctx.fillStyle = enemy?.isControlledUndead ? "rgba(120, 144, 255, 0.45)" : "rgba(120, 208, 255, 0.45)";
     ctx.fillRect(screenX - half * 0.72, bodyTop, half * 1.44, half * 1.15);
   },
 


### PR DESCRIPTION
• This branch adds a full third playable class, the Reformed Necromancer, and then iterates heavily on its pet-control gameplay. The class can charm ghosts and skeletons with a beam,
  heal allied undead with that same beam, and use Death Bolt as a pulsing necrotic AoE that damages enemies, heals pets, and later buffs pet damage. Its progression tree was split
  into Control Mastery, Death Bolt, and Augment Death, with control cap, charm speed, pet stat scaling, death explosions, and death-bolt empowerment all tuned across several passes.

  A large part of the work is in AI/faction behavior. Charmed undead are now treated as real allies: they persist between floors, get tinted blue, follow in a formation, respect line
  of sight for target acquisition, ignore dormant mimics and currently charmed targets, and interact with enemy contact damage using cooldown-based retaliation instead of constant
  mutual collision damage. There are also stability fixes around pet spawning between floors, leash-based cleanup for lost pets, safer door interaction changes from earlier work, and
  HUD/UI additions to surface pet count and necromancer-specific skill behavior. Overall, this branch turns the necromancer from a concept into a working pet class with bespoke
  combat, AI, rendering, and progression support.