### PR TITLE
Multiplayer2

### DIFF
--- a/docs/CONSUMABLES_SHOP_DESIGN.md
+++ b/docs/CONSUMABLES_SHOP_DESIGN.md
@@ -1,0 +1,363 @@
+# Consumables Shop Design
+
+This document captures the v1 redesign of the shop around consumable items.
+
+The current shop previously overlapped heavily with the talent system by offering permanent upgrades. Permanent progression now lives in the talent tree, so the shop is being repositioned as a source of temporary utility, tactical options, and emergency resources during a run.
+
+This document is the canonical design reference for the consumables shop MVP and the item schema used to author shop content consistently.
+
+## Design Goals
+
+- Replace permanent shop upgrades entirely with consumables
+- Differentiate the shop from the talent tree
+- Give the player meaningful tactical and strategic purchasing decisions during a run
+- Support both manually activated and automatically triggered consumables
+- Keep the system readable in the shop, on the HUD, and in combat
+
+## Core Definition
+
+A consumable is a shop item that:
+
+- has limited quantity
+- can only be held up to a per-item cap
+- is consumed when used actively or when its trigger event occurs passively
+- appears in the HUD while owned
+
+Consumables persist only for the current run. They do not persist between runs, and runs cannot be resumed later.
+
+## Consumable Types
+
+Consumables are divided by how they are triggered.
+
+### Active
+
+- Triggered manually by the player
+- Bound to numeric keys `1-5`
+- Consume `1` charge on successful use
+- If use fails because conditions are invalid, no charge is consumed
+- All active consumables share a global internal cooldown of `2s`
+
+### Passive
+
+- Trigger automatically when their item-specific condition occurs
+- Consume `1` charge when they successfully trigger
+- Do not use the shared `2s` active cooldown
+- May define their own item-specific internal cooldowns
+- Passive cooldown is tracked per item stack
+- Trigger at most once per event instance
+
+There are no active/passive hybrid items in v1.
+
+## Inventory Rules
+
+Consumables are held as stacks of charges.
+
+### Active Inventory
+
+- The player may hold up to `5` active consumable types at once
+- These map directly to hotbar slots and keys `1-5`
+- New active consumables are assigned to the first open slot
+- Active consumables are ordered by acquisition
+- Buying another copy of an active consumable already owned adds `1` charge to that slot
+- If all `5` active slots are occupied, the player cannot acquire a new active consumable type
+
+### Passive Inventory
+
+- The player may hold up to `3` passive consumable slots at once
+- Stacked copies of the same passive consumable share one slot
+- Passive consumables resolve in acquisition order, oldest first
+- If all `3` passive slots are occupied, the player cannot acquire a new passive consumable type
+
+### Per-Item Carry Limits
+
+- Every consumable has its own max owned quantity
+- A common default is `3`, but this is item-specific
+- Some consumables may have lower or higher limits
+- Passive consumables are often expected to have lower limits or item-specific cooldown constraints
+
+## Acquisition Rules
+
+Consumables are purchased through the shop interface.
+
+- Each purchase grants `1` charge
+- The same consumable may be purchased multiple times in a shop visit if stock and inventory limits allow
+- The shop itself also has limited stock per item
+- Shop stock refills only when the current floor is completed
+
+### Purchase Failure States
+
+Purchases should be blocked and message the player clearly when:
+
+- `At max stack`
+- `No active slot available`
+- `No passive slot available`
+- `Out of stock`
+
+If the player attempts to buy a consumable at capacity, the purchase is blocked rather than wasted.
+
+## Shop Structure
+
+The shop contains only consumables.
+
+- Each floor shop presents `5` item entries
+- Shop stock is randomized each floor
+- Duplicate entries may not appear in the same shop
+- Some items may only enter the shop pool after a certain floor is reached
+
+## Rarity And Shop Generation
+
+Items have rarity, and rarity affects how shop inventory is generated.
+
+The intended process for each of the `5` shop entries is:
+
+1. Roll on the common table with equal weight
+2. `20%` of the common table is represented by "roll a rare item instead"
+3. If the entry upgrades to rare, roll on the rare table with equal weight
+4. `20%` of the rare table is represented by "roll a legendary item instead"
+5. If the entry upgrades to legendary, roll on the legendary table with equal weight
+
+Fallback rule:
+
+- If a target rarity has no remaining eligible unique items, roll the next lower rarity tier instead
+- The downgrade path is `Legendary -> Rare -> Common`
+- If the common pool also has no remaining eligible unique items, continue rerolling until a valid shop entry is produced from the remaining eligible pool
+
+## Pricing
+
+- Consumable pricing scales by floor
+- Exact pricing is tuned per item
+- Pricing does not scale based on current owned quantity
+
+## HUD
+
+### Active HUD
+
+Active consumables appear in a hotbar at the bottom of the screen near the XP bar.
+
+Each active slot should show:
+
+- item icon
+- keybind
+- current charge count
+- cooldown feedback
+
+Because the active cooldown is shared globally, all active consumables should visually indicate cooldown when any active consumable has been used.
+
+### Passive HUD
+
+Passive consumables appear to the right of the active hotbar area.
+
+- Passive icons are only shown while owned
+- Passive items remain visible while on their own item-specific cooldown
+- Passive items should show cooldown feedback if applicable
+- If the last charge is consumed, the passive icon disappears immediately
+
+## Tooltip Structure
+
+Tooltip text should follow a consistent structure.
+
+Recommended order:
+
+1. `Active` or `Passive`
+2. Short effect summary
+3. Trigger or use details
+4. Duration and cooldown information
+5. Owned count and max allowed
+6. Price
+7. Rarity
+
+## Behavioral Rules
+
+### Active Use
+
+- One keypress attempts one use
+- One successful use consumes `1` charge
+- Failed use consumes no charge
+- Any successful active use triggers the shared `2s` active cooldown
+- If an active consumable applies a timed effect that is already active, using it again refreshes the duration instead of stacking the effect
+
+### Passive Triggering
+
+- Trigger conditions are defined per item
+- A passive item may trigger once per qualifying event instance
+- A successful trigger consumes `1` charge
+- Some passive items may define their own internal cooldown before another charge of that same item stack can trigger again
+- If multiple passive items match the same event, they resolve in acquisition order, oldest first
+- Matching passive items continue resolving in order even if an earlier passive changes the original triggering condition
+
+## Item Schema
+
+To keep item design consistent, every consumable must conform to a shared schema.
+
+All items must define the following fields:
+
+- `Name`
+- `Type`
+- `Rarity`
+- `Trigger Condition`
+- `Cooldown`
+- `Unlock Floor`
+- `Price`
+- `Max Stack`
+- `Max Inventory`
+- `Effect`
+
+### Field Rules
+
+- `Name`
+  - The display name of the consumable
+- `Type`
+  - Must be either `Active` or `Passive`
+  - There are no hybrid items in v1
+- `Rarity`
+  - Must be one of `Common`, `Rare`, or `Legendary`
+- `Trigger Condition`
+  - Required for passive items
+  - For active items, this should be recorded as `N/A`
+- `Cooldown`
+  - Records the cooldown behavior for the item
+  - Use `Default` when the item uses the system default behavior
+  - Use a specific value when the item defines an item-specific cooldown
+- `Unlock Floor`
+  - The earliest floor where the item may appear in the shop pool
+- `Price`
+  - The shop purchase cost for one charge
+- `Max Stack`
+  - The maximum number of charges the player may hold for that consumable
+- `Max Inventory`
+  - The maximum amount of that consumable the shop may stock when it appears
+- `Effect`
+  - A concise rules description of what the consumable does when used or triggered
+
+This schema is mandatory for all consumables. Item ideas should not be considered complete until all schema fields are defined.
+
+## Item Creation Workflow
+
+All new consumables should be created using the same workflow so they remain consistent with the rest of the shop system.
+
+1. Define the item using the mandatory schema
+2. Verify that `Type` is strictly `Active` or `Passive`
+3. Verify that `Rarity` is strictly `Common`, `Rare`, or `Legendary`
+4. For passive items, define a clear `Trigger Condition`
+5. For active items, record `Trigger Condition` as `N/A`
+6. Define `Cooldown` and `Unlock Floor`
+7. Define `Price`, `Max Stack`, and `Max Inventory`
+8. Write the `Effect` as concise gameplay-facing rules text
+9. Confirm the item respects v1 constraints such as no hybrid behavior, slot limits, and run-only persistence
+
+The schema should be treated as the canonical starting point for new item design.
+
+## Example Consumables
+
+### Angel Ring
+
+- `Name`: Angel Ring
+- `Type`: Passive
+- `Rarity`: Rare
+- `Trigger Condition`: When the player would hit `0 HP`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 2000
+- `Max Stack`: `1`
+- `Max Inventory`: `1`
+- `Effect`: Heal the player for `20%` HP immediately
+
+### Regeneration Potion
+
+- `Name`: Regeneration Potion
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 100
+- `Max Stack`: 3
+- `Max Inventory`: 2
+- `Effect`: The player regenerates `20%` of health over `10s`
+
+### Speed Potion
+
+- `Name`: Speed Potion
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 100
+- `Max Stack`: 3
+- `Max Inventory`: 2
+- `Effect`: The player gains `+20%` movement speed for `10s`
+
+### Frost Oil
+
+- `Name`: Frost Oil
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 50
+- `Max Stack`: 3
+- `Max Inventory`: 2
+- `Effect`: For the next `5s`, attacks deal `+2` cold damage and enemies struck are slowed by `15%` for `3s`
+
+### Fire Oil
+
+- `Name`: Fire Oil
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 50
+- `Max Stack`: 3
+- `Max Inventory`: 2
+- `Effect`: For the next `5s`, attacks deal `+2` fire damage and enemies struck burn for `2s`
+
+### Spike Growth
+
+- `Name`: Spike Growth
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 50
+- `Max Stack`: 3
+- `Max Inventory`: 2
+- `Effect`: For `5s` after activation, enemies that attack the player take `+3` retaliatory damage
+
+### Shield
+
+- `Name`: Shield
+- `Type`: Active
+- `Rarity`: Common
+- `Trigger Condition`: `N/A`
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 3
+- `Max Stack`: 2
+- `Max Inventory`: 2
+- `Effect`: Gain `10` temporary HP
+
+### Monkey Paw
+
+- `Name`: Monkey Paw
+- `Type`: Passive
+- `Rarity`: Legendary
+- `Trigger Condition`: On moving to the next floor
+- `Cooldown`: Default
+- `Unlock Floor`: 1
+- `Price`: 1000
+- `Max Stack`: `1`
+- `Max Inventory`: `1`
+- `Effect`: Remove all consumables, fully heal the player, and immediately grant a level
+
+## Non-Goals For V1
+
+- No permanent shop upgrades
+- No manual hotbar reordering
+- No dropping, selling, replacing, or discarding consumables
+- No active/passive hybrid items
+- No between-run persistence
+- No save/load run resumption

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -121,7 +121,11 @@ This document summarizes the current high-level architecture and validation work
   - predicted arrows render faintly and expire visually before their reconciliation records are discarded
   - authoritative arrows are culled from the network presentation path after their lifetime expires
   - delta snapshot merging skips reconciled predicted arrows so matched local projectiles are not reinserted as stale artifacts
+  - projectile, fire-zone, and melee-swing snapshots preserve renderer metadata such as damage type, doctrine, style, modifier, execute state, and visual timing fields so multiplayer effects use the same renderer branches as local play
+  - replicated player rigs use serialized cooldown state for attack/cast pulse instead of rendering remote players with a static rig pose
 - The authoritative room still keeps one primary `sim.player` path for the pause owner, but snapshots now also serialize a `players` collection for all active participants.
+- Authoritative player-state copying lives in `server/net/activePlayerState.js`; keep new multiplayer player fields there instead of duplicating mappings inside `AuthoritativeRoom`.
+- Player snapshot DTO fields live in `src/net/playerSnapshotSchema.js`; server serialization and client snapshot application both use this schema to reduce single-player/multiplayer state drift.
 - The client runtime resolves the local player out of `state.players`, keeps remote players in `game.remotePlayers`, and renders/interpolates them separately from the local predicted avatar.
 - The network render/runtime path now reads the active `netClient` dynamically instead of capturing a stale pre-connect reference, which keeps multiplayer UI actions working after live room join.
 - The browser debug surface in `game.js` now exposes enough live state for Playwright-based network validation and perf harnesses.
@@ -140,6 +144,8 @@ This document summarizes the current high-level architecture and validation work
   - projectile reconciliation rejects with reason, seq, owner, projectile type, predicted/authoritative positions, and distance
   - render context such as viewport, canvas size, device pixel ratio, visibility/focus state, renderer mode, reduced-motion media flags, and observed frame cadence
 - Correction telemetry distinguishes lifetime floor-load synchronization from post-load gameplay corrections. This keeps unavoidable initial map/player adoption corrections from hiding actual in-play hard snaps or blocked corrections.
+- The network flight recorder keeps a bounded snapshot-application trail for multiplayer movement debugging. Each event records controller/local-controller state, ack sequence, pending input depth, jitter, frame gap, correction kind, total correction debt, applied correction step, and before/server/after positions.
+- `window.__WOTC_DEBUG__.run("dumpNetworkFlightRecorder")` returns recent flight events plus correction tails so Playwright harnesses and manual captures can inspect the same data.
 - The network smoothness validator records matching browser/render context so manual 30 FPS reports can be compared against automated active-tab 60 FPS runs.
 
 ### Optional Agora Voice
@@ -234,6 +240,8 @@ This document summarizes the current high-level architecture and validation work
 - `validate:network-combat-hit`
   - measures attack emission, enemy HP confirmation, and floating-text confirmation in browser play
   - now uses reliable target-selection and repositioning so misses on drifting enemies do not masquerade as combat-feedback regressions
+- `validate:player-state-sync`
+  - verifies authoritative active-player adapter round trips, serialized active-player snapshot fields, and client snapshot application for player build/runtime state
 - `validate:network-shared-rewards`
   - verifies authoritative two-player XP/gold reward sharing and master-volume output scaling
 - `validate:network-archer`
@@ -241,8 +249,13 @@ This document summarizes the current high-level architecture and validation work
   - now retries moving-shot samples and records skipped attempts so authoritative-visibility timing noise does not make the suite flaky
 - `validate:network-projectiles`
   - verifies local projectile prediction cadence, reconciliation, stale-prediction cleanup, and delta-merge behavior for networked ranged attacks
+- `validate:network-vfx-snapshots`
+  - verifies multiplayer projectile, fire-zone, and melee-swing snapshots preserve renderer-facing VFX metadata through server serialization, keyframe deltas, and client snapshot application
 - `validate:network-smoothness`
   - verifies controller movement, peer-observed remote movement, active-tab frame cadence, post-load correction metrics, projectile visibility latency, held-primary shot cadence, and lingering projectile cleanup
+- `validate:network-rubberband-soak`
+  - runs one browser-controlled player plus five WebSocket bots against a loopback server, then fails on post-load hard snaps, correction debt, applied correction step, movement discontinuity, and pending-input backlog budgets
+  - writes success/failure artifacts under `artifacts/network/` with flight-recorder events, movement summaries, bot totals, debug state, and a screenshot on failure
 - `validate:network-floor-movement`
   - verifies each class can load floor 1 in multiplayer, move after load, pause/resume, tick lantern fuel, see enemies, keep the canvas visible, and continue control after pause-owner death transfer
 - `validate:dev-network-telemetry`

--- a/docs/TECHNICAL_OVERVIEW.md
+++ b/docs/TECHNICAL_OVERVIEW.md
@@ -114,6 +114,9 @@ This document summarizes the current high-level architecture and validation work
   - local-player prediction/reconciliation
   - map chunk readiness
   - projectile reconciliation
+- Server-side input handling queues incoming client inputs and promotes them into the authoritative simulation tick before snapshotting. Snapshot `lastInputSeqByPlayer` values mean "processed by the sim", not merely "received by the socket", so clients only discard predicted inputs after the authoritative state has actually consumed them.
+- Snapshot payloads also include per-player received-input sequence and server queue depth for diagnostics.
+- Delta snapshots send explicit `null` values when previously serialized optional fields disappear. This prevents stale client-side presentation state such as expired enemy burn/curse/rot timers from surviving until the next keyframe and creating false status icons or burning-enemy lights.
 - Network presentation is tuned to keep multiplayer close to single-player feel:
   - local controller movement remains predicted while authoritative snapshots reconcile position
   - stale large startup corrections are separated from post-load gameplay correction metrics
@@ -142,6 +145,7 @@ This document summarizes the current high-level architecture and validation work
   - regular frame/network state
   - frame spikes over the configured threshold
   - projectile reconciliation rejects with reason, seq, owner, projectile type, predicted/authoritative positions, and distance
+  - suspicious state markers such as enemy status fanout and visible player mimic runtime
   - render context such as viewport, canvas size, device pixel ratio, visibility/focus state, renderer mode, reduced-motion media flags, and observed frame cadence
 - Correction telemetry distinguishes lifetime floor-load synchronization from post-load gameplay corrections. This keeps unavoidable initial map/player adoption corrections from hiding actual in-play hard snaps or blocked corrections.
 - The network flight recorder keeps a bounded snapshot-application trail for multiplayer movement debugging. Each event records controller/local-controller state, ack sequence, pending input depth, jitter, frame gap, correction kind, total correction debt, applied correction step, and before/server/after positions.
@@ -251,6 +255,8 @@ This document summarizes the current high-level architecture and validation work
   - verifies local projectile prediction cadence, reconciliation, stale-prediction cleanup, and delta-merge behavior for networked ranged attacks
 - `validate:network-vfx-snapshots`
   - verifies multiplayer projectile, fire-zone, and melee-swing snapshots preserve renderer-facing VFX metadata through server serialization, keyframe deltas, and client snapshot application
+- `validate:network-state-corruption`
+  - reproduces stale player mimic runtime, enemy status fanout, mimic enemy presentation state, and render-stall status aging so multiplayer state corruption remains visible in validation and telemetry
 - `validate:network-smoothness`
   - verifies controller movement, peer-observed remote movement, active-tab frame cadence, post-load correction metrics, projectile visibility latency, held-primary shot cadence, and lingering projectile cleanup
 - `validate:network-rubberband-soak`

--- a/game.js
+++ b/game.js
@@ -1236,6 +1236,12 @@ if (typeof window !== "undefined") {
               y: enemy.y,
               hp: enemy.hp,
               maxHp: enemy.maxHp,
+              hpBarTimer: Number.isFinite(enemy.hpBarTimer) ? enemy.hpBarTimer : 0,
+              burningTimer: Number.isFinite(enemy.burningTimer) ? enemy.burningTimer : 0,
+              curseTimer: Number.isFinite(enemy.curseTimer) ? enemy.curseTimer : 0,
+              rotTimer: Number.isFinite(enemy.rotTimer) ? enemy.rotTimer : 0,
+              burningDps: Number.isFinite(enemy.burningDps) ? enemy.burningDps : 0,
+              rotDps: Number.isFinite(enemy.rotDps) ? enemy.rotDps : 0,
               size: enemy.size || 0,
               distToPlayer: Math.hypot((enemy.x || 0) - playerX, (enemy.y || 0) - playerY),
               screenX: (enemy.x || 0) - camera.x,
@@ -1510,6 +1516,14 @@ if (typeof window !== "undefined") {
               projectileReconcileRejects: game.networkPerf.projectileReconcileRejects || 0,
               recentProjectileReconcileRejects: Array.isArray(game.networkPerf.recentProjectileReconcileRejects)
                 ? game.networkPerf.recentProjectileReconcileRejects.slice(-8)
+                : [],
+              networkStateAnomalyEventId: game.networkPerf.networkStateAnomalyEventId || 0,
+              recentStateAnomalies: Array.isArray(game.networkPerf.recentStateAnomalies)
+                ? game.networkPerf.recentStateAnomalies.slice(-12).map((entry) => ({ ...entry }))
+                : [],
+              serverStateAnomalyEventId: game.networkPerf.serverStateAnomalyEventId || 0,
+              recentServerStateAnomalies: Array.isArray(game.networkPerf.recentServerStateAnomalies)
+                ? game.networkPerf.recentServerStateAnomalies.slice(-12).map((entry) => ({ ...entry }))
                 : [],
               recentCorrections: Array.isArray(game.networkPerf.recentCorrections)
                 ? game.networkPerf.recentCorrections.slice(-8)
@@ -1892,6 +1906,7 @@ function startNetworkRenderLoop(game) {
     isNetworkController: () => hasLocalPrediction(game),
     getRenderDelayMs: () => getRenderDelayForRole(() => hasLocalPrediction(game), NET_RENDER_DELAY_MS_CONTROLLER, NET_RENDER_DELAY_MS_SPECTATOR),
     estimateServerNowMs: () => estimateServerNowMsFromState(netClockState),
+    getAckSeqForPacket: getAckSeqForMessage,
     consumeSnapshotForRender,
     netSnapshotBuffer,
     maxSnapshotBuffer: NET_MAX_SNAPSHOT_BUFFER,

--- a/game.js
+++ b/game.js
@@ -1133,6 +1133,16 @@ if (typeof window !== "undefined") {
       if (torch.lit) torch.snuffCooldown = 0;
       return { ok: true, id: torch.id || null, lit: torch.lit };
     }
+    if (action === "dumpNetworkFlightRecorder") {
+      const perf = game.networkPerf && typeof game.networkPerf === "object" ? game.networkPerf : {};
+      return {
+        ok: true,
+        eventId: Number.isFinite(perf.networkFlightEventId) ? perf.networkFlightEventId : 0,
+        events: Array.isArray(perf.recentFlightEvents) ? perf.recentFlightEvents.map((entry) => ({ ...entry })) : [],
+        corrections: Array.isArray(perf.recentCorrections) ? perf.recentCorrections.map((entry) => ({ ...entry })) : [],
+        postLoadCorrections: Array.isArray(perf.recentPostLoadCorrections) ? perf.recentPostLoadCorrections.map((entry) => ({ ...entry })) : []
+      };
+    }
     if (action === "setPaused") {
       game.paused = payload.paused === true;
       if (!game.paused && game.input) {
@@ -1490,6 +1500,10 @@ if (typeof window !== "undefined") {
               postLoadBlockedSnapCount: game.networkPerf.postLoadBlockedSnapCount || 0,
               recentPostLoadCorrections: Array.isArray(game.networkPerf.recentPostLoadCorrections)
                 ? game.networkPerf.recentPostLoadCorrections.slice(-8)
+                : [],
+              networkFlightEventId: game.networkPerf.networkFlightEventId || 0,
+              recentFlightEvents: Array.isArray(game.networkPerf.recentFlightEvents)
+                ? game.networkPerf.recentFlightEvents.slice(-24).map((entry) => ({ ...entry }))
                 : [],
               lastReplayMode: game.networkPerf.lastReplayMode || "",
               lastPredictionPressure: game.networkPerf.lastPredictionPressure || null,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validate:network-floor-movement": "node server/validate-network-floor-movement.js",
     "validate:network-projectiles": "node server/validate-network-projectile-prediction.js",
     "validate:network-smoothness": "node server/validate-network-smoothness.js",
+    "validate:network-rubberband-soak": "node server/validate-network-rubberband-soak.js",
     "validate:dev-network-telemetry": "node server/validate-dev-network-telemetry.js",
     "validate:mobile-transport": "node server/validate-mobile-transport-defaults.js",
     "validate:network-framework": "node server/validate-network-framework-evaluation.js",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "validate:network-combat": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat.js')).href))\"",
     "validate:network-combat-hit": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat-hit.js')).href))\"",
     "validate:network-shop": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-shop.js')).href))\"",
+    "validate:player-state-sync": "node server/validate-player-state-sync.js",
     "validate:network-shared-rewards": "node server/validate-network-shared-rewards.js",
     "validate:network-two-client-damage": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-two-client-damage.js')).href))\"",
     "validate:network-archer": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-archer.js')).href))\"",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "validate:network-combat": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat.js')).href))\"",
     "validate:network-combat-hit": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat-hit.js')).href))\"",
     "validate:network-vfx-snapshots": "node server/validate-network-vfx-snapshots.js",
+    "validate:network-state-corruption": "node server/validate-network-state-corruption.js",
     "validate:network-shop": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-shop.js')).href))\"",
     "validate:player-state-sync": "node server/validate-player-state-sync.js",
     "validate:network-shared-rewards": "node server/validate-network-shared-rewards.js",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "validate:network-join": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-join.js')).href))\"",
     "validate:network-combat": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat.js')).href))\"",
     "validate:network-combat-hit": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-combat-hit.js')).href))\"",
+    "validate:network-vfx-snapshots": "node server/validate-network-vfx-snapshots.js",
     "validate:network-shop": "node -e \"Promise.all([import('node:path'), import('node:url')]).then(([{ resolve }, { pathToFileURL }]) => import(pathToFileURL(resolve(process.env.INIT_CWD || process.cwd(), 'server/validate-network-shop.js')).href))\"",
     "validate:player-state-sync": "node server/validate-player-state-sync.js",
     "validate:network-shared-rewards": "node server/validate-network-shared-rewards.js",

--- a/server/devNetworkTelemetryApi.js
+++ b/server/devNetworkTelemetryApi.js
@@ -54,6 +54,49 @@ function sanitizeProjectileRejectEvent(entry) {
   };
 }
 
+function sanitizeStateAnomalyEvent(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  return {
+    id: Number.isFinite(entry.id) ? Math.floor(entry.id) : null,
+    atMs: Number.isFinite(entry.atMs) ? Math.max(0, Math.round(entry.atMs)) : null,
+    kind: typeof entry.kind === "string" ? entry.kind.slice(0, 64) : "",
+    keyframe: typeof entry.keyframe === "boolean" ? entry.keyframe : null,
+    ackSeq: Number.isFinite(entry.ackSeq) ? Math.floor(entry.ackSeq) : null,
+    enemyCount: Number.isFinite(entry.enemyCount) ? Math.floor(entry.enemyCount) : null,
+    tripleStatusCount: Number.isFinite(entry.tripleStatusCount) ? Math.floor(entry.tripleStatusCount) : null,
+    fullHpBarCount: Number.isFinite(entry.fullHpBarCount) ? Math.floor(entry.fullHpBarCount) : null,
+    localMimicTimer: Number.isFinite(entry.localMimicTimer) ? entry.localMimicTimer : null,
+    remoteMimicCount: Number.isFinite(entry.remoteMimicCount) ? Math.floor(entry.remoteMimicCount) : null,
+    remotePlayerIds: Array.isArray(entry.remotePlayerIds)
+      ? entry.remotePlayerIds
+          .filter((id) => typeof id === "string" && id)
+          .slice(0, 6)
+          .map((id) => id.slice(0, 80))
+      : []
+  };
+}
+
+function sanitizeServerStateAnomalyEvent(entry) {
+  if (!entry || typeof entry !== "object") return null;
+  const sanitizeEntityList = (list) =>
+    Array.isArray(list)
+      ? list.slice(0, 4).map((item) => (item && typeof item === "object" ? { ...item } : null)).filter(Boolean)
+      : [];
+  return {
+    id: Number.isFinite(entry.id) ? Math.floor(entry.id) : null,
+    atMs: Number.isFinite(entry.atMs) ? Math.max(0, Math.round(entry.atMs)) : null,
+    snapshotSeq: Number.isFinite(entry.snapshotSeq) ? Math.floor(entry.snapshotSeq) : null,
+    kind: typeof entry.kind === "string" ? entry.kind.slice(0, 64) : "",
+    paused: typeof entry.paused === "boolean" ? entry.paused : null,
+    context: entry.context && typeof entry.context === "object" ? { ...entry.context } : null,
+    enemyCount: Number.isFinite(entry.enemyCount) ? Math.floor(entry.enemyCount) : null,
+    tripleStatusCount: Number.isFinite(entry.tripleStatusCount) ? Math.floor(entry.tripleStatusCount) : null,
+    tripleStatusEnemies: sanitizeEntityList(entry.tripleStatusEnemies),
+    mimicPlayers: sanitizeEntityList(entry.mimicPlayers),
+    classMismatches: sanitizeEntityList(entry.classMismatches)
+  };
+}
+
 function finiteNumberOrNull(value) {
   return Number.isFinite(value) ? value : null;
 }
@@ -118,6 +161,12 @@ function sanitizeSample(sample) {
   const recentProjectileReconcileRejects = Array.isArray(sample.recentProjectileReconcileRejects)
     ? sample.recentProjectileReconcileRejects.slice(-8).map(sanitizeProjectileRejectEvent).filter(Boolean)
     : [];
+  const recentStateAnomalies = Array.isArray(sample.recentStateAnomalies)
+    ? sample.recentStateAnomalies.slice(-8).map(sanitizeStateAnomalyEvent).filter(Boolean)
+    : [];
+  const recentServerStateAnomalies = Array.isArray(sample.recentServerStateAnomalies)
+    ? sample.recentServerStateAnomalies.slice(-8).map(sanitizeServerStateAnomalyEvent).filter(Boolean)
+    : [];
   return {
     kind,
     at: typeof sample.at === "string" ? sample.at : new Date().toISOString(),
@@ -165,6 +214,10 @@ function sanitizeSample(sample) {
     projectileReconcileRejects: Number.isFinite(sample.projectileReconcileRejects) ? sample.projectileReconcileRejects : null,
     projectileReconcileRejectDelta: Number.isFinite(sample.projectileReconcileRejectDelta) ? sample.projectileReconcileRejectDelta : null,
     recentProjectileReconcileRejects,
+    networkStateAnomalyEventId: Number.isFinite(sample.networkStateAnomalyEventId) ? Math.floor(sample.networkStateAnomalyEventId) : null,
+    recentStateAnomalies,
+    serverStateAnomalyEventId: Number.isFinite(sample.serverStateAnomalyEventId) ? Math.floor(sample.serverStateAnomalyEventId) : null,
+    recentServerStateAnomalies,
     visibleProjectiles: Number.isFinite(sample.visibleProjectiles) ? sample.visibleProjectiles : null,
     visibleRangerProjectiles: Number.isFinite(sample.visibleRangerProjectiles) ? sample.visibleRangerProjectiles : null,
     ownedProjectiles: Number.isFinite(sample.ownedProjectiles) ? sample.ownedProjectiles : null,

--- a/server/net/AuthoritativeRoom.js
+++ b/server/net/AuthoritativeRoom.js
@@ -1,11 +1,14 @@
 import { GameSim } from "../../src/sim/GameSim.js";
-import { cloneRangerTalentState, createRangerTalentState } from "../../src/game/rangerTalentTree.js";
-import { cloneWarriorTalentState, createWarriorTalentState } from "../../src/game/warriorTalentTree.js";
-import { cloneNecromancerTalentState, createNecromancerTalentState } from "../../src/game/necromancerTalentTree.js";
-import { cloneConsumableInventoryState } from "../../src/game/consumables.js";
-import { cloneNecromancerBeamState, cloneNecromancerRuntimeState, cloneRangerRuntimeState, cloneSkillState, cloneUpgradeState, cloneWarriorRuntimeState } from "./playerStateCloneHelpers.js";
+import { cloneNecromancerBeamState } from "./playerStateCloneHelpers.js";
 import { buildAgoraVoiceUid, buildVoiceClientConfig } from "./voiceConfig.js";
 import { createRandomActivePlayerStates, placeActivePlayersAtRandomFloorSpawns } from "./floorTransitionHelpers.js";
+import {
+  createActivePlayerStateForRoom,
+  createPlayerSimulationContextForRoom,
+  syncActivePlayerStateFromContextForRoom,
+  syncPrimaryActivePlayerFromSimForRoom,
+  syncSimPrimaryPlayerStateForRoom
+} from "./activePlayerState.js";
 
 const PLAYER_COLOR_PALETTE = ["#5bb3ff", "#ff8f6b", "#7ae582", "#f3cf6b", "#c78bff", "#ff6fae"];
 
@@ -172,62 +175,7 @@ export class AuthoritativeRoom {
   }
 
   createActivePlayerState(client, spawn = null) {
-    const classSpec = this.getClassSpec(client?.classType);
-    const baseMaxHealth = Number.isFinite(classSpec.baseMaxHealth) ? classSpec.baseMaxHealth : this.sim.config?.player?.maxHealth || 100;
-    const x = Number.isFinite(spawn?.x) ? spawn.x : this.sim.player?.x || 0;
-    const y = Number.isFinite(spawn?.y) ? spawn.y : this.sim.player?.y || 0;
-    return {
-      id: client.id,
-      handle: client.name,
-      classType: client.classType,
-      x,
-      y,
-      size: Number.isFinite(this.sim.player?.size) ? this.sim.player.size : 22,
-      speed: Number.isFinite(classSpec.baseMoveSpeed) ? classSpec.baseMoveSpeed : this.sim.config?.player?.speed || 180,
-      health: baseMaxHealth,
-      maxHealth: baseMaxHealth,
-      level: 1,
-      score: 0,
-      gold: 0,
-      experience: 0,
-      expToNextLevel: this.sim.config?.progression?.baseXpToLevel || 10,
-      skillPoints: 0,
-      refundCount: 0,
-      levelWeaponDamageBonus: 0,
-      lanternFuel: Number.isFinite(spawn?.lanternFuel) ? spawn.lanternFuel : this.sim.config?.lighting?.lanternInitialFuel,
-      kills: 0,
-      damageDealt: 0,
-      goldEarned: 0,
-      fireCooldown: 0,
-      fireArrowCooldown: 0,
-      deathBoltCooldown: 0,
-      skills: cloneSkillState(),
-      rangerTalents: createRangerTalentState(),
-      warriorTalents: createWarriorTalentState(),
-      necromancerTalents: createNecromancerTalentState(),
-      upgrades: cloneUpgradeState(),
-      consumables: cloneConsumableInventoryState(),
-      rangerRuntime: cloneRangerRuntimeState(),
-      warriorRuntime: cloneWarriorRuntimeState(),
-      necromancerRuntime: cloneNecromancerRuntimeState(),
-      consumableRuntime: { tempHp: 0 },
-      warriorMomentumTimer: 0,
-      warriorRageActiveTimer: 0,
-      warriorRageCooldownTimer: 0,
-      warriorRageVictoryRushPool: 0,
-      warriorRageVictoryRushTimer: 0,
-      necromancerBeam: cloneNecromancerBeamState(),
-      hitCooldown: 0,
-      hpBarTimer: 0,
-      animTime: 0,
-      dirX: 1,
-      dirY: 0,
-      facing: 0,
-      moving: false,
-      alive: true,
-      spectateTargetId: "",
-      color: this.getClientRunColor(client)
-    };
+    return createActivePlayerStateForRoom(this, client, spawn);
   }
 
   buildRunParticipantRecord(client, state = null, outcome = "Dead") {
@@ -283,191 +231,19 @@ export class AuthoritativeRoom {
   }
 
   syncSimPrimaryPlayerState() {
-    if (!this.pauseOwnerId) return null;
-    const client = this.clients.get(this.pauseOwnerId);
-    const state = client ? this.activePlayers.get(client.id) : null;
-    if (!client || !state) return null;
-    const classSpec = this.getClassSpec(state.classType);
-    this.sim.classType = state.classType;
-    this.sim.classSpec = classSpec;
-    this.sim.player.classType = state.classType;
-    this.sim.player.id = state.id;
-    this.sim.player.handle = state.handle;
-    this.sim.player.color = state.color;
-    this.sim.player.x = Number.isFinite(state.x) ? state.x : this.sim.player.x;
-    this.sim.player.y = Number.isFinite(state.y) ? state.y : this.sim.player.y;
-    this.sim.player.size = Number.isFinite(state.size) ? state.size : this.sim.player.size;
-    this.sim.player.speed = Number.isFinite(state.speed) ? state.speed : this.sim.player.speed;
-    this.sim.player.health = Number.isFinite(state.health) ? state.health : this.sim.player.health;
-    this.sim.player.maxHealth = Number.isFinite(state.maxHealth) ? state.maxHealth : this.sim.player.maxHealth;
-    this.sim.player.alive = this.sim.player.health > 0;
-    this.sim.player.fireCooldown = Number.isFinite(state.fireCooldown) ? state.fireCooldown : 0;
-    this.sim.player.fireArrowCooldown = Number.isFinite(state.fireArrowCooldown) ? state.fireArrowCooldown : 0;
-    this.sim.player.deathBoltCooldown = Number.isFinite(state.deathBoltCooldown) ? state.deathBoltCooldown : 0;
-    this.sim.player.hitCooldown = Number.isFinite(state.hitCooldown) ? state.hitCooldown : 0;
-    this.sim.player.hpBarTimer = Number.isFinite(state.hpBarTimer) ? state.hpBarTimer : 0;
-    this.sim.player.animTime = Number.isFinite(state.animTime) ? state.animTime : 0;
-    this.sim.player.dirX = Number.isFinite(state.dirX) ? state.dirX : this.sim.player.dirX;
-    this.sim.player.dirY = Number.isFinite(state.dirY) ? state.dirY : this.sim.player.dirY;
-    this.sim.player.facing = Number.isFinite(state.facing) ? state.facing : this.sim.player.facing;
-    this.sim.player.moving = !!state.moving;
-    this.sim.level = Number.isFinite(state.level) ? state.level : this.sim.level;
-    this.sim.score = Number.isFinite(state.score) ? state.score : this.sim.score;
-    this.sim.gold = Number.isFinite(state.gold) ? state.gold : this.sim.gold;
-    this.sim.experience = Number.isFinite(state.experience) ? state.experience : this.sim.experience;
-    this.sim.expToNextLevel = Number.isFinite(state.expToNextLevel) ? state.expToNextLevel : this.sim.expToNextLevel;
-    this.sim.skillPoints = Number.isFinite(state.skillPoints) ? state.skillPoints : this.sim.skillPoints;
-    this.sim.refundCount = Number.isFinite(state.refundCount) ? state.refundCount : this.sim.refundCount;
-    this.sim.levelWeaponDamageBonus = Number.isFinite(state.levelWeaponDamageBonus) ? state.levelWeaponDamageBonus : this.sim.levelWeaponDamageBonus;
-    this.sim.skills = cloneSkillState(state.skills);
-    this.sim.rangerTalents = cloneRangerTalentState(state.rangerTalents);
-    this.sim.warriorTalents = cloneWarriorTalentState(state.warriorTalents);
-    this.sim.necromancerTalents = cloneNecromancerTalentState(state.necromancerTalents);
-    this.sim.upgrades = cloneUpgradeState(state.upgrades);
-    this.sim.consumables = cloneConsumableInventoryState(state.consumables);
-    this.sim.rangerRuntime = cloneRangerRuntimeState(state.rangerRuntime);
-    this.sim.warriorRuntime = cloneWarriorRuntimeState(state.warriorRuntime);
-    this.sim.player.consumableRuntime = {
-      tempHp: Number.isFinite(state?.consumableRuntime?.tempHp) ? state.consumableRuntime.tempHp : 0
-    };
-    this.sim.warriorMomentumTimer = Number.isFinite(state.warriorMomentumTimer) ? state.warriorMomentumTimer : 0;
-    this.sim.warriorRageActiveTimer = Number.isFinite(state.warriorRageActiveTimer) ? state.warriorRageActiveTimer : 0;
-    this.sim.warriorRageCooldownTimer = Number.isFinite(state.warriorRageCooldownTimer) ? state.warriorRageCooldownTimer : 0;
-    this.sim.warriorRageVictoryRushPool = Number.isFinite(state.warriorRageVictoryRushPool) ? state.warriorRageVictoryRushPool : 0;
-    this.sim.warriorRageVictoryRushTimer = Number.isFinite(state.warriorRageVictoryRushTimer) ? state.warriorRageVictoryRushTimer : 0;
-    this.sim.necromancerBeam = cloneNecromancerBeamState(state.necromancerBeam);
-    return state;
+    return syncSimPrimaryPlayerStateForRoom(this);
   }
 
   syncPrimaryActivePlayerFromSim() {
-    if (!this.pauseOwnerId) return null;
-    const client = this.clients.get(this.pauseOwnerId);
-    if (!client) return null;
-    const state = this.activePlayers.get(client.id) || this.createActivePlayerState(client, this.sim.player);
-    state.handle = client.name;
-    state.classType = client.classType;
-    state.x = this.sim.player.x;
-    state.y = this.sim.player.y;
-    state.size = this.sim.player.size;
-    state.health = this.sim.player.health;
-    state.maxHealth = this.sim.player.maxHealth;
-    state.fireCooldown = this.sim.player.fireCooldown;
-    state.fireArrowCooldown = this.sim.player.fireArrowCooldown;
-    state.deathBoltCooldown = this.sim.player.deathBoltCooldown;
-    state.skills = cloneSkillState(this.sim.skills);
-    state.rangerTalents = cloneRangerTalentState(this.sim.rangerTalents);
-    state.warriorTalents = cloneWarriorTalentState(this.sim.warriorTalents);
-    state.necromancerTalents = cloneNecromancerTalentState(this.sim.necromancerTalents);
-    state.upgrades = cloneUpgradeState(this.sim.upgrades);
-    state.consumables = cloneConsumableInventoryState(this.sim.consumables);
-    state.rangerRuntime = cloneRangerRuntimeState(this.sim.rangerRuntime);
-    state.warriorRuntime = cloneWarriorRuntimeState(this.sim.warriorRuntime);
-    state.score = this.sim.score;
-    state.gold = this.sim.gold;
-    state.experience = this.sim.experience;
-    state.expToNextLevel = this.sim.expToNextLevel;
-    state.skillPoints = this.sim.skillPoints;
-    state.refundCount = Number.isFinite(this.sim.refundCount) ? this.sim.refundCount : 0;
-    state.levelWeaponDamageBonus = this.sim.levelWeaponDamageBonus;
-    state.lanternFuel = this.sim.player.lanternFuel;
-    state.kills = this.sim.runStats?.totalKills || 0;
-    state.damageDealt = this.sim.runStats?.damageDealt || 0;
-    state.goldEarned = this.sim.runStats?.goldEarned || 0;
-    state.warriorMomentumTimer = this.sim.warriorMomentumTimer || 0;
-    state.warriorRageActiveTimer = this.sim.warriorRageActiveTimer || 0;
-    state.warriorRageCooldownTimer = this.sim.warriorRageCooldownTimer || 0;
-    state.warriorRageVictoryRushPool = this.sim.warriorRageVictoryRushPool || 0;
-    state.warriorRageVictoryRushTimer = this.sim.warriorRageVictoryRushTimer || 0;
-    state.necromancerBeam = cloneNecromancerBeamState(this.sim.necromancerBeam);
-    state.hitCooldown = this.sim.player.hitCooldown;
-    state.hpBarTimer = this.sim.player.hpBarTimer;
-    state.animTime = this.sim.player.animTime;
-    state.level = this.sim.level;
-    state.dirX = this.sim.player.dirX;
-    state.dirY = this.sim.player.dirY;
-    state.facing = this.sim.player.facing;
-    state.moving = !!this.sim.player.moving;
-    state.alive = this.sim.player.health > 0;
-    state.spectateTargetId = state.alive ? "" : (typeof client.input?.spectateTargetId === "string" ? client.input.spectateTargetId : "");
-    state.consumableRuntime = {
-      tempHp: Number.isFinite(this.sim.player?.consumableRuntime?.tempHp) ? this.sim.player.consumableRuntime.tempHp : 0
-    };
-    state.color = this.getClientRunColor(client);
-    this.activePlayers.set(client.id, state);
-    return state;
+    return syncPrimaryActivePlayerFromSimForRoom(this);
   }
 
   createPlayerSimulationContext(state) {
-    if (!state) return null;
-    const context = Object.create(this.sim);
-    context.player = state;
-    context.classType = state.classType;
-    context.classSpec = this.getClassSpec(state.classType);
-    context.level = Number.isFinite(state.level) ? state.level : 1;
-    context.score = Number.isFinite(state.score) ? state.score : 0;
-    context.gold = Number.isFinite(state.gold) ? state.gold : 0;
-    context.experience = Number.isFinite(state.experience) ? state.experience : 0;
-    context.expToNextLevel = Number.isFinite(state.expToNextLevel)
-      ? state.expToNextLevel
-      : this.sim.config?.progression?.baseXpToLevel || 10;
-    context.skillPoints = Number.isFinite(state.skillPoints) ? state.skillPoints : 0;
-    context.refundCount = Number.isFinite(state.refundCount) ? state.refundCount : 0;
-    context.levelWeaponDamageBonus = Number.isFinite(state.levelWeaponDamageBonus) ? state.levelWeaponDamageBonus : 0;
-    context.skills = cloneSkillState(state.skills);
-    context.rangerTalents = cloneRangerTalentState(state.rangerTalents);
-    context.warriorTalents = cloneWarriorTalentState(state.warriorTalents);
-    context.necromancerTalents = cloneNecromancerTalentState(state.necromancerTalents);
-    context.upgrades = cloneUpgradeState(state.upgrades);
-    context.consumables = cloneConsumableInventoryState(state.consumables);
-    context.rangerRuntime = cloneRangerRuntimeState(state.rangerRuntime);
-    context.warriorRuntime = cloneWarriorRuntimeState(state.warriorRuntime);
-    context.necromancerRuntime = cloneNecromancerRuntimeState(state.necromancerRuntime);
-    context.player.consumableRuntime = {
-      tempHp: Number.isFinite(state?.consumableRuntime?.tempHp) ? state.consumableRuntime.tempHp : 0
-    };
-    context.warriorMomentumTimer = Number.isFinite(state.warriorMomentumTimer) ? state.warriorMomentumTimer : 0;
-    context.warriorRageActiveTimer = Number.isFinite(state.warriorRageActiveTimer) ? state.warriorRageActiveTimer : 0;
-    context.warriorRageCooldownTimer = Number.isFinite(state.warriorRageCooldownTimer) ? state.warriorRageCooldownTimer : 0;
-    context.warriorRageVictoryRushPool = Number.isFinite(state.warriorRageVictoryRushPool) ? state.warriorRageVictoryRushPool : 0;
-    context.warriorRageVictoryRushTimer = Number.isFinite(state.warriorRageVictoryRushTimer) ? state.warriorRageVictoryRushTimer : 0;
-    context.necromancerBeam = cloneNecromancerBeamState(state.necromancerBeam);
-    context.recordRunGoldSpent = () => {};
-    context.recordClassSpecificStat = () => {};
-    return context;
+    return createPlayerSimulationContextForRoom(this, state);
   }
 
   syncActivePlayerStateFromContext(state, context) {
-    if (!state || !context) return;
-    state.classType = context.classType;
-    state.level = Number.isFinite(context.level) ? context.level : state.level;
-    state.score = Number.isFinite(context.score) ? context.score : state.score;
-    state.gold = Number.isFinite(context.gold) ? context.gold : state.gold;
-    state.experience = Number.isFinite(context.experience) ? context.experience : state.experience;
-    state.expToNextLevel = Number.isFinite(context.expToNextLevel) ? context.expToNextLevel : state.expToNextLevel;
-    state.skillPoints = Number.isFinite(context.skillPoints) ? context.skillPoints : state.skillPoints;
-    state.refundCount = Number.isFinite(context.refundCount) ? context.refundCount : state.refundCount;
-    state.levelWeaponDamageBonus = Number.isFinite(context.levelWeaponDamageBonus)
-      ? context.levelWeaponDamageBonus
-      : state.levelWeaponDamageBonus;
-    state.skills = cloneSkillState(context.skills);
-    state.rangerTalents = cloneRangerTalentState(context.rangerTalents);
-    state.warriorTalents = cloneWarriorTalentState(context.warriorTalents);
-    state.necromancerTalents = cloneNecromancerTalentState(context.necromancerTalents);
-    state.upgrades = cloneUpgradeState(context.upgrades);
-    state.consumables = cloneConsumableInventoryState(context.consumables);
-    state.rangerRuntime = cloneRangerRuntimeState(context.rangerRuntime);
-    state.warriorRuntime = cloneWarriorRuntimeState(context.warriorRuntime);
-    state.necromancerRuntime = cloneNecromancerRuntimeState(context.necromancerRuntime);
-    state.consumableRuntime = {
-      tempHp: Number.isFinite(context?.player?.consumableRuntime?.tempHp) ? context.player.consumableRuntime.tempHp : 0
-    };
-    state.warriorMomentumTimer = Number.isFinite(context.warriorMomentumTimer) ? context.warriorMomentumTimer : 0;
-    state.warriorRageActiveTimer = Number.isFinite(context.warriorRageActiveTimer) ? context.warriorRageActiveTimer : 0;
-    state.warriorRageCooldownTimer = Number.isFinite(context.warriorRageCooldownTimer) ? context.warriorRageCooldownTimer : 0;
-    state.warriorRageVictoryRushPool = Number.isFinite(context.warriorRageVictoryRushPool) ? context.warriorRageVictoryRushPool : 0;
-    state.warriorRageVictoryRushTimer = Number.isFinite(context.warriorRageVictoryRushTimer) ? context.warriorRageVictoryRushTimer : 0;
-    state.necromancerBeam = cloneNecromancerBeamState(context.necromancerBeam);
-    if (typeof context.getPlayerMoveSpeed === "function") state.speed = context.getPlayerMoveSpeed();
+    syncActivePlayerStateFromContextForRoom(state, context);
   }
 
   beamHasLineOfSight(x0, y0, x1, y1) {

--- a/server/net/AuthoritativeRoom.js
+++ b/server/net/AuthoritativeRoom.js
@@ -3,6 +3,13 @@ import { cloneNecromancerBeamState } from "./playerStateCloneHelpers.js";
 import { buildAgoraVoiceUid, buildVoiceClientConfig } from "./voiceConfig.js";
 import { createRandomActivePlayerStates, placeActivePlayersAtRandomFloorSpawns } from "./floorTransitionHelpers.js";
 import {
+  getInputQueueDepth,
+  getProcessedInputSeq,
+  getReceivedInputSeq,
+  promoteQueuedClientInput,
+  resetClientInputState
+} from "./clientInputQueue.js";
+import {
   createActivePlayerStateForRoom,
   createPlayerSimulationContextForRoom,
   syncActivePlayerStateFromContextForRoom,
@@ -45,6 +52,9 @@ export class AuthoritativeRoom {
     this.currentMusicTrack = this.options.chooseGameplayTrack();
     this.snapshotCounter = 0;
     this.snapshotSeq = 0;
+    this.serverStateAnomalyEventId = 0;
+    this.recentServerStateAnomalies = [];
+    this.lastServerStateAnomalySignature = "";
     this.telemetry = {
       tickDurationsMs: [],
       serializeDurationsMs: [],
@@ -246,6 +256,130 @@ export class AuthoritativeRoom {
     syncActivePlayerStateFromContextForRoom(state, context);
   }
 
+  trimServerStateAnomalies(limit = 48) {
+    if (this.recentServerStateAnomalies.length > limit) {
+      this.recentServerStateAnomalies.splice(0, this.recentServerStateAnomalies.length - limit);
+    }
+  }
+
+  getPlayerAuditRecords() {
+    const records = [];
+    const pushRecord = (source, player) => {
+      if (!player) return;
+      const id = typeof player.id === "string" ? player.id : "";
+      const client = id ? this.clients.get(id) : null;
+      records.push({
+        source,
+        id,
+        classType: typeof player.classType === "string" ? player.classType : "",
+        clientClassType: typeof client?.classType === "string" ? client.classType : "",
+        health: Number.isFinite(player.health) ? player.health : null,
+        alive: player.alive !== false && (!Number.isFinite(player.health) || player.health > 0),
+        mimicTimer: Number.isFinite(player.necromancerRuntime?.mimicTimer) ? player.necromancerRuntime.mimicTimer : 0,
+        mimicHealth: Number.isFinite(player.necromancerRuntime?.mimicHealth) ? player.necromancerRuntime.mimicHealth : 0
+      });
+    };
+    pushRecord("simPrimary", this.sim.player);
+    for (const state of this.activePlayers.values()) pushRecord("activePlayer", state);
+    return records;
+  }
+
+  collectServerStateAudit() {
+    const tripleStatusEnemies = [];
+    for (const enemy of Array.isArray(this.sim.enemies) ? this.sim.enemies : []) {
+      if (!enemy || (enemy.hp || 0) <= 0) continue;
+      const burningTimer = Number.isFinite(enemy.burningTimer) ? enemy.burningTimer : 0;
+      const curseTimer = Number.isFinite(enemy.curseTimer) ? enemy.curseTimer : 0;
+      const rotTimer = Number.isFinite(enemy.rotTimer) ? enemy.rotTimer : 0;
+      if (!(burningTimer > 0 && curseTimer > 0 && rotTimer > 0)) continue;
+      tripleStatusEnemies.push({
+        id: this.options.getStableId(this, "enemy", "e", enemy),
+        type: typeof enemy.type === "string" ? enemy.type : "",
+        hp: Number.isFinite(enemy.hp) ? enemy.hp : null,
+        maxHp: Number.isFinite(enemy.maxHp) ? enemy.maxHp : null,
+        burningTimer,
+        curseTimer,
+        rotTimer,
+        burningDps: Number.isFinite(enemy.burningDps) ? enemy.burningDps : 0,
+        rotDps: Number.isFinite(enemy.rotDps) ? enemy.rotDps : 0
+      });
+    }
+
+    const players = this.getPlayerAuditRecords();
+    const mimicPlayers = players.filter((player) => player.mimicTimer > 0 || player.mimicHealth > 0);
+    const classMismatches = players.filter((player) =>
+      player.id &&
+      player.clientClassType &&
+      player.classType &&
+      player.classType !== player.clientClassType
+    );
+    const parts = [];
+    if (tripleStatusEnemies.length >= 3) {
+      parts.push(`enemyStatusFanout:${tripleStatusEnemies.map((enemy) => enemy.id).join(",")}`);
+    }
+    if (mimicPlayers.length > 0) {
+      parts.push(`playerMimicRuntimeVisible:${mimicPlayers.map((player) => `${player.source}:${player.id}:${Math.round(player.mimicTimer * 10)}`).join(",")}`);
+    }
+    if (classMismatches.length > 0) {
+      parts.push(`playerClassMismatch:${classMismatches.map((player) => `${player.source}:${player.id}:${player.classType}->${player.clientClassType}`).join(",")}`);
+    }
+    return {
+      signature: parts.join("|"),
+      tripleStatusEnemies,
+      mimicPlayers,
+      classMismatches
+    };
+  }
+
+  recordServerStateAnomaly(kind, details = {}) {
+    this.serverStateAnomalyEventId += 1;
+    const event = {
+      id: this.serverStateAnomalyEventId,
+      atMs: Date.now(),
+      snapshotSeq: this.snapshotSeq,
+      phase: this.phase,
+      paused: !!this.sim.paused,
+      kind,
+      controllerId: this.pauseOwnerId || null,
+      lastInputSeqByPlayer: this.getLastInputSeqByPlayer(),
+      inputQueueDepthByPlayer: this.getInputQueueDepthByPlayer(),
+      ...details
+    };
+    this.recentServerStateAnomalies.push(event);
+    this.trimServerStateAnomalies();
+    return event;
+  }
+
+  auditServerState(context = {}) {
+    const audit = this.collectServerStateAudit();
+    if (!audit.signature || audit.signature === this.lastServerStateAnomalySignature) return null;
+    this.lastServerStateAnomalySignature = audit.signature;
+    const kind = audit.tripleStatusEnemies.length >= 3
+      ? "enemyStatusFanout"
+      : audit.mimicPlayers.length > 0
+      ? "playerMimicRuntimeVisible"
+      : "playerClassMismatch";
+    return this.recordServerStateAnomaly(kind, {
+      context,
+      signature: audit.signature,
+      enemyCount: Array.isArray(this.sim.enemies) ? this.sim.enemies.length : 0,
+      tripleStatusCount: audit.tripleStatusEnemies.length,
+      tripleStatusEnemies: audit.tripleStatusEnemies.slice(0, 8),
+      mimicPlayers: audit.mimicPlayers.slice(0, 8),
+      classMismatches: audit.classMismatches.slice(0, 8)
+    });
+  }
+
+  clearQueuedCombatInputFlags(clients = this.clients.values()) {
+    for (const client of clients) {
+      if (!client?.input) continue;
+      client.input.swapAttackQueued = false;
+      client.input.firePrimaryQueued = false;
+      client.input.fireAltQueued = false;
+      client.input.modeSwapQueued = false;
+    }
+  }
+
   beamHasLineOfSight(x0, y0, x1, y1) {
     const dx = x1 - x0;
     const dy = y1 - y0;
@@ -440,7 +574,13 @@ export class AuthoritativeRoom {
     };
     const result = fn(context, state);
     this.syncActivePlayerStateFromContext(state, context);
-    this.tagNewProjectilesForPlayer(beforeCounts, clientId, this.clients.get(clientId)?.lastInputSeq || 0);
+    this.tagNewProjectilesForPlayer(beforeCounts, clientId, getProcessedInputSeq(this.clients.get(clientId)));
+    this.auditServerState({
+      source: "activePlayerAction",
+      playerId: clientId,
+      classType: state.classType,
+      processedInputSeq: getProcessedInputSeq(this.clients.get(clientId))
+    });
     return result;
   }
 
@@ -616,7 +756,23 @@ export class AuthoritativeRoom {
   getLastInputSeqByPlayer() {
     const out = {};
     for (const client of this.clients.values()) {
-      out[client.id] = Number.isFinite(client.lastInputSeq) ? client.lastInputSeq : 0;
+      out[client.id] = getProcessedInputSeq(client);
+    }
+    return out;
+  }
+
+  getLastReceivedInputSeqByPlayer() {
+    const out = {};
+    for (const client of this.clients.values()) {
+      out[client.id] = getReceivedInputSeq(client);
+    }
+    return out;
+  }
+
+  getInputQueueDepthByPlayer() {
+    const out = {};
+    for (const client of this.clients.values()) {
+      out[client.id] = getInputQueueDepth(client);
     }
     return out;
   }
@@ -682,6 +838,7 @@ export class AuthoritativeRoom {
     if (this.requestedStartFloor > 1 && typeof this.sim.applyDebugStartingFloor === "function") {
       this.sim.applyDebugStartingFloor(this.requestedStartFloor);
     }
+    for (const client of this.clients.values()) resetClientInputState(client, this.options.makeDefaultInput);
     this.initializeActivePlayers();
     this.completedRunPlayers.clear();
     this.finalResults = null;
@@ -726,6 +883,9 @@ export class AuthoritativeRoom {
     this.lastSnapshotPortalActive = null;
     this.snapshotCounter = 0;
     this.snapshotSeq = 0;
+    this.serverStateAnomalyEventId = 0;
+    this.recentServerStateAnomalies = [];
+    this.lastServerStateAnomalySignature = "";
     this.deltaCache = {
       enemies: new Map(),
       drops: new Map(),
@@ -762,8 +922,7 @@ export class AuthoritativeRoom {
       wallTrap: new WeakMap()
     };
     for (const client of this.clients.values()) {
-      client.input = this.options.makeDefaultInput();
-      client.lastInputSeq = 0;
+      resetClientInputState(client, this.options.makeDefaultInput);
       client.lastSnapshotAckSeq = 0;
       client.classLocked = false;
     }
@@ -844,6 +1003,10 @@ export class AuthoritativeRoom {
     return client.input;
   }
 
+  promoteQueuedClientInputs() {
+    for (const client of this.clients.values()) promoteQueuedClientInput(client);
+  }
+
   updateClientLobbyState(clientId, { classType, locked } = {}) {
     const client = this.clients.get(clientId);
     if (!client) return false;
@@ -889,7 +1052,6 @@ export class AuthoritativeRoom {
       return;
     }
     this.sim.activePlayerCount = Math.max(1, this.clients.size);
-    if (typeof this.sim.ensurePlayerSafePosition === "function") this.sim.ensurePlayerSafePosition(12);
     this.tickDriftSampleCounter += 1;
     if (Number.isFinite(scheduleDriftMs)) {
       if (scheduleDriftMs > this.options.tickDriftEpsilonMs) {
@@ -905,10 +1067,30 @@ export class AuthoritativeRoom {
       }
     }
     const t0 = this.options.monotonicNowMs();
+    const rawDt = Number.isFinite(nowMs) && Number.isFinite(this.lastTickMs)
+      ? (nowMs - this.lastTickMs) / 1000
+      : 0;
+    const dt = Math.min(Math.max(rawDt, 0), 0.05);
+    if (rawDt < -0.001) {
+      this.recordServerStateAnomaly("negativeTickDelta", {
+        context: {
+          source: "tickClock",
+          rawDtMs: Math.round(rawDt * 1000),
+          previousTickMs: this.lastTickMs,
+          nowMs
+        }
+      });
+    }
+    this.lastTickMs = nowMs;
+    this.promoteQueuedClientInputs();
+    if (this.sim.paused && !this.sim.gameOver) {
+      this.clearQueuedCombatInputFlags();
+      this.options.pushTelemetrySample(this.telemetry.tickDurationsMs, this.options.monotonicNowMs() - t0);
+      return;
+    }
+    if (typeof this.sim.ensurePlayerSafePosition === "function") this.sim.ensurePlayerSafePosition(12);
     const preBulletCount = this.sim.bullets.length;
     const preFireArrowCount = this.sim.fireArrows.length;
-    const dt = Math.min((nowMs - this.lastTickMs) / 1000, 0.05);
-    this.lastTickMs = nowMs;
     const previousFloor = Number.isFinite(this.sim.floor) ? this.sim.floor : null;
     this.sim.networkActivePlayers = this.getSimulationPlayerEntities();
     this.sim.tick(dt, this.getControllerInput());
@@ -924,7 +1106,7 @@ export class AuthoritativeRoom {
     }
     if (typeof this.sim.ensurePlayerSafePosition === "function") this.sim.ensurePlayerSafePosition(12);
     const controllerClient = this.clients.get(this.pauseOwnerId);
-    const taggedSeq = controllerClient ? controllerClient.input?.seq || controllerClient.lastInputSeq || 0 : 0;
+    const taggedSeq = getProcessedInputSeq(controllerClient);
     const ownerId = this.pauseOwnerId || null;
     for (let i = preBulletCount; i < this.sim.bullets.length; i++) {
       const bullet = this.sim.bullets[i];
@@ -939,12 +1121,14 @@ export class AuthoritativeRoom {
       if (!(Number.isFinite(fireArrow.spawnSeq) && fireArrow.spawnSeq > 0)) fireArrow.spawnSeq = taggedSeq;
       if (!(typeof fireArrow.ownerId === "string" && fireArrow.ownerId)) fireArrow.ownerId = ownerId;
     }
-    if (controllerClient) {
-      controllerClient.input.swapAttackQueued = false;
-      controllerClient.input.firePrimaryQueued = false;
-      controllerClient.input.fireAltQueued = false;
-      controllerClient.input.modeSwapQueued = false;
-    }
+    if (controllerClient) this.clearQueuedCombatInputFlags([controllerClient]);
+    this.auditServerState({
+      source: "tick",
+      dtMs: Math.round(dt * 1000),
+      rawDtMs: Math.round(rawDt * 1000),
+      controllerId: this.pauseOwnerId || null,
+      processedInputSeq: getProcessedInputSeq(controllerClient)
+    });
     this.options.pushTelemetrySample(this.telemetry.tickDurationsMs, this.options.monotonicNowMs() - t0);
   }
 
@@ -1111,6 +1295,10 @@ export class AuthoritativeRoom {
     const controllerClient = this.clients.get(this.pauseOwnerId);
     const serializeStart = this.options.monotonicNowMs();
     const fullState = this.options.serializeState(this);
+    this.auditServerState({
+      source: "snapshot",
+      force: !!force
+    });
     this.options.pushTelemetrySample(this.telemetry.serializeDurationsMs, this.options.monotonicNowMs() - serializeStart);
     this.snapshotCounter += 1;
     this.snapshotSeq += 1;
@@ -1154,6 +1342,7 @@ export class AuthoritativeRoom {
       time: fullState.time,
       player: fullState.player,
       players: fullState.players,
+      serverStateAnomalies: this.recentServerStateAnomalies.slice(-12).map((entry) => ({ ...entry })),
       delta
     };
     if (keyframe || floorStateChanged) state.floor = fullState.floor;
@@ -1173,8 +1362,10 @@ export class AuthoritativeRoom {
       ownerId: this.roomOwnerId,
       pauseOwnerId: this.pauseOwnerId,
       controllerId: this.pauseOwnerId,
-      lastInputSeq: controllerClient ? controllerClient.lastInputSeq : 0,
+      lastInputSeq: getProcessedInputSeq(controllerClient),
       lastInputSeqByPlayer: this.getLastInputSeqByPlayer(),
+      lastReceivedInputSeqByPlayer: this.getLastReceivedInputSeqByPlayer(),
+      inputQueueDepthByPlayer: this.getInputQueueDepthByPlayer(),
       mapSignature: sig,
       state
     });

--- a/server/net/activePlayerState.js
+++ b/server/net/activePlayerState.js
@@ -115,6 +115,8 @@ export function syncSimPrimaryPlayerStateForRoom(room) {
   room.sim.consumables = cloneConsumableInventoryState(state.consumables);
   room.sim.rangerRuntime = cloneRangerRuntimeState(state.rangerRuntime);
   room.sim.warriorRuntime = cloneWarriorRuntimeState(state.warriorRuntime);
+  room.sim.necromancerRuntime = cloneNecromancerRuntimeState(state.necromancerRuntime);
+  room.sim.player.necromancerRuntime = room.sim.necromancerRuntime;
   room.sim.player.consumableRuntime = {
     tempHp: Number.isFinite(state?.consumableRuntime?.tempHp) ? state.consumableRuntime.tempHp : 0
   };
@@ -150,6 +152,7 @@ export function syncPrimaryActivePlayerFromSimForRoom(room) {
   state.consumables = cloneConsumableInventoryState(room.sim.consumables);
   state.rangerRuntime = cloneRangerRuntimeState(room.sim.rangerRuntime);
   state.warriorRuntime = cloneWarriorRuntimeState(room.sim.warriorRuntime);
+  state.necromancerRuntime = cloneNecromancerRuntimeState(room.sim.necromancerRuntime);
   state.score = room.sim.score;
   state.gold = room.sim.gold;
   state.experience = room.sim.experience;

--- a/server/net/activePlayerState.js
+++ b/server/net/activePlayerState.js
@@ -1,0 +1,259 @@
+import { createRangerTalentState, cloneRangerTalentState } from "../../src/game/rangerTalentTree.js";
+import { createWarriorTalentState, cloneWarriorTalentState } from "../../src/game/warriorTalentTree.js";
+import { createNecromancerTalentState, cloneNecromancerTalentState } from "../../src/game/necromancerTalentTree.js";
+import { cloneConsumableInventoryState } from "../../src/game/consumables.js";
+import {
+  cloneNecromancerBeamState,
+  cloneNecromancerRuntimeState,
+  cloneRangerRuntimeState,
+  cloneSkillState,
+  cloneUpgradeState,
+  cloneWarriorRuntimeState
+} from "./playerStateCloneHelpers.js";
+
+export function createActivePlayerStateForRoom(room, client, spawn = null) {
+  const classSpec = room.getClassSpec(client?.classType);
+  const baseMaxHealth = Number.isFinite(classSpec.baseMaxHealth) ? classSpec.baseMaxHealth : room.sim.config?.player?.maxHealth || 100;
+  const x = Number.isFinite(spawn?.x) ? spawn.x : room.sim.player?.x || 0;
+  const y = Number.isFinite(spawn?.y) ? spawn.y : room.sim.player?.y || 0;
+  return {
+    id: client.id,
+    handle: client.name,
+    classType: client.classType,
+    x,
+    y,
+    size: Number.isFinite(room.sim.player?.size) ? room.sim.player.size : 22,
+    speed: Number.isFinite(classSpec.baseMoveSpeed) ? classSpec.baseMoveSpeed : room.sim.config?.player?.speed || 180,
+    health: baseMaxHealth,
+    maxHealth: baseMaxHealth,
+    level: 1,
+    score: 0,
+    gold: 0,
+    experience: 0,
+    expToNextLevel: room.sim.config?.progression?.baseXpToLevel || 10,
+    skillPoints: 0,
+    refundCount: 0,
+    levelWeaponDamageBonus: 0,
+    lanternFuel: Number.isFinite(spawn?.lanternFuel) ? spawn.lanternFuel : room.sim.config?.lighting?.lanternInitialFuel,
+    kills: 0,
+    damageDealt: 0,
+    goldEarned: 0,
+    fireCooldown: 0,
+    fireArrowCooldown: 0,
+    deathBoltCooldown: 0,
+    skills: cloneSkillState(),
+    rangerTalents: createRangerTalentState(),
+    warriorTalents: createWarriorTalentState(),
+    necromancerTalents: createNecromancerTalentState(),
+    upgrades: cloneUpgradeState(),
+    consumables: cloneConsumableInventoryState(),
+    rangerRuntime: cloneRangerRuntimeState(),
+    warriorRuntime: cloneWarriorRuntimeState(),
+    necromancerRuntime: cloneNecromancerRuntimeState(),
+    consumableRuntime: { tempHp: 0 },
+    warriorMomentumTimer: 0,
+    warriorRageActiveTimer: 0,
+    warriorRageCooldownTimer: 0,
+    warriorRageVictoryRushPool: 0,
+    warriorRageVictoryRushTimer: 0,
+    necromancerBeam: cloneNecromancerBeamState(),
+    hitCooldown: 0,
+    hpBarTimer: 0,
+    animTime: 0,
+    dirX: 1,
+    dirY: 0,
+    facing: 0,
+    moving: false,
+    alive: true,
+    spectateTargetId: "",
+    color: room.getClientRunColor(client)
+  };
+}
+
+export function syncSimPrimaryPlayerStateForRoom(room) {
+  if (!room.pauseOwnerId) return null;
+  const client = room.clients.get(room.pauseOwnerId);
+  const state = client ? room.activePlayers.get(client.id) : null;
+  if (!client || !state) return null;
+  const classSpec = room.getClassSpec(state.classType);
+  room.sim.classType = state.classType;
+  room.sim.classSpec = classSpec;
+  room.sim.player.classType = state.classType;
+  room.sim.player.id = state.id;
+  room.sim.player.handle = state.handle;
+  room.sim.player.color = state.color;
+  room.sim.player.x = Number.isFinite(state.x) ? state.x : room.sim.player.x;
+  room.sim.player.y = Number.isFinite(state.y) ? state.y : room.sim.player.y;
+  room.sim.player.size = Number.isFinite(state.size) ? state.size : room.sim.player.size;
+  room.sim.player.speed = Number.isFinite(state.speed) ? state.speed : room.sim.player.speed;
+  room.sim.player.health = Number.isFinite(state.health) ? state.health : room.sim.player.health;
+  room.sim.player.maxHealth = Number.isFinite(state.maxHealth) ? state.maxHealth : room.sim.player.maxHealth;
+  room.sim.player.alive = room.sim.player.health > 0;
+  room.sim.player.fireCooldown = Number.isFinite(state.fireCooldown) ? state.fireCooldown : 0;
+  room.sim.player.fireArrowCooldown = Number.isFinite(state.fireArrowCooldown) ? state.fireArrowCooldown : 0;
+  room.sim.player.deathBoltCooldown = Number.isFinite(state.deathBoltCooldown) ? state.deathBoltCooldown : 0;
+  room.sim.player.hitCooldown = Number.isFinite(state.hitCooldown) ? state.hitCooldown : 0;
+  room.sim.player.hpBarTimer = Number.isFinite(state.hpBarTimer) ? state.hpBarTimer : 0;
+  room.sim.player.animTime = Number.isFinite(state.animTime) ? state.animTime : 0;
+  room.sim.player.dirX = Number.isFinite(state.dirX) ? state.dirX : room.sim.player.dirX;
+  room.sim.player.dirY = Number.isFinite(state.dirY) ? state.dirY : room.sim.player.dirY;
+  room.sim.player.facing = Number.isFinite(state.facing) ? state.facing : room.sim.player.facing;
+  room.sim.player.moving = !!state.moving;
+  room.sim.level = Number.isFinite(state.level) ? state.level : room.sim.level;
+  room.sim.score = Number.isFinite(state.score) ? state.score : room.sim.score;
+  room.sim.gold = Number.isFinite(state.gold) ? state.gold : room.sim.gold;
+  room.sim.experience = Number.isFinite(state.experience) ? state.experience : room.sim.experience;
+  room.sim.expToNextLevel = Number.isFinite(state.expToNextLevel) ? state.expToNextLevel : room.sim.expToNextLevel;
+  room.sim.skillPoints = Number.isFinite(state.skillPoints) ? state.skillPoints : room.sim.skillPoints;
+  room.sim.refundCount = Number.isFinite(state.refundCount) ? state.refundCount : room.sim.refundCount;
+  room.sim.levelWeaponDamageBonus = Number.isFinite(state.levelWeaponDamageBonus) ? state.levelWeaponDamageBonus : room.sim.levelWeaponDamageBonus;
+  room.sim.skills = cloneSkillState(state.skills);
+  room.sim.rangerTalents = cloneRangerTalentState(state.rangerTalents);
+  room.sim.warriorTalents = cloneWarriorTalentState(state.warriorTalents);
+  room.sim.necromancerTalents = cloneNecromancerTalentState(state.necromancerTalents);
+  room.sim.upgrades = cloneUpgradeState(state.upgrades);
+  room.sim.consumables = cloneConsumableInventoryState(state.consumables);
+  room.sim.rangerRuntime = cloneRangerRuntimeState(state.rangerRuntime);
+  room.sim.warriorRuntime = cloneWarriorRuntimeState(state.warriorRuntime);
+  room.sim.player.consumableRuntime = {
+    tempHp: Number.isFinite(state?.consumableRuntime?.tempHp) ? state.consumableRuntime.tempHp : 0
+  };
+  room.sim.warriorMomentumTimer = Number.isFinite(state.warriorMomentumTimer) ? state.warriorMomentumTimer : 0;
+  room.sim.warriorRageActiveTimer = Number.isFinite(state.warriorRageActiveTimer) ? state.warriorRageActiveTimer : 0;
+  room.sim.warriorRageCooldownTimer = Number.isFinite(state.warriorRageCooldownTimer) ? state.warriorRageCooldownTimer : 0;
+  room.sim.warriorRageVictoryRushPool = Number.isFinite(state.warriorRageVictoryRushPool) ? state.warriorRageVictoryRushPool : 0;
+  room.sim.warriorRageVictoryRushTimer = Number.isFinite(state.warriorRageVictoryRushTimer) ? state.warriorRageVictoryRushTimer : 0;
+  room.sim.necromancerBeam = cloneNecromancerBeamState(state.necromancerBeam);
+  return state;
+}
+
+export function syncPrimaryActivePlayerFromSimForRoom(room) {
+  if (!room.pauseOwnerId) return null;
+  const client = room.clients.get(room.pauseOwnerId);
+  if (!client) return null;
+  const state = room.activePlayers.get(client.id) || createActivePlayerStateForRoom(room, client, room.sim.player);
+  state.handle = client.name;
+  state.classType = client.classType;
+  state.x = room.sim.player.x;
+  state.y = room.sim.player.y;
+  state.size = room.sim.player.size;
+  state.health = room.sim.player.health;
+  state.maxHealth = room.sim.player.maxHealth;
+  state.fireCooldown = room.sim.player.fireCooldown;
+  state.fireArrowCooldown = room.sim.player.fireArrowCooldown;
+  state.deathBoltCooldown = room.sim.player.deathBoltCooldown;
+  state.skills = cloneSkillState(room.sim.skills);
+  state.rangerTalents = cloneRangerTalentState(room.sim.rangerTalents);
+  state.warriorTalents = cloneWarriorTalentState(room.sim.warriorTalents);
+  state.necromancerTalents = cloneNecromancerTalentState(room.sim.necromancerTalents);
+  state.upgrades = cloneUpgradeState(room.sim.upgrades);
+  state.consumables = cloneConsumableInventoryState(room.sim.consumables);
+  state.rangerRuntime = cloneRangerRuntimeState(room.sim.rangerRuntime);
+  state.warriorRuntime = cloneWarriorRuntimeState(room.sim.warriorRuntime);
+  state.score = room.sim.score;
+  state.gold = room.sim.gold;
+  state.experience = room.sim.experience;
+  state.expToNextLevel = room.sim.expToNextLevel;
+  state.skillPoints = room.sim.skillPoints;
+  state.refundCount = Number.isFinite(room.sim.refundCount) ? room.sim.refundCount : 0;
+  state.levelWeaponDamageBonus = room.sim.levelWeaponDamageBonus;
+  state.lanternFuel = room.sim.player.lanternFuel;
+  state.kills = room.sim.runStats?.totalKills || 0;
+  state.damageDealt = room.sim.runStats?.damageDealt || 0;
+  state.goldEarned = room.sim.runStats?.goldEarned || 0;
+  state.warriorMomentumTimer = room.sim.warriorMomentumTimer || 0;
+  state.warriorRageActiveTimer = room.sim.warriorRageActiveTimer || 0;
+  state.warriorRageCooldownTimer = room.sim.warriorRageCooldownTimer || 0;
+  state.warriorRageVictoryRushPool = room.sim.warriorRageVictoryRushPool || 0;
+  state.warriorRageVictoryRushTimer = room.sim.warriorRageVictoryRushTimer || 0;
+  state.necromancerBeam = cloneNecromancerBeamState(room.sim.necromancerBeam);
+  state.hitCooldown = room.sim.player.hitCooldown;
+  state.hpBarTimer = room.sim.player.hpBarTimer;
+  state.animTime = room.sim.player.animTime;
+  state.level = room.sim.level;
+  state.dirX = room.sim.player.dirX;
+  state.dirY = room.sim.player.dirY;
+  state.facing = room.sim.player.facing;
+  state.moving = !!room.sim.player.moving;
+  state.alive = room.sim.player.health > 0;
+  state.spectateTargetId = state.alive ? "" : (typeof client.input?.spectateTargetId === "string" ? client.input.spectateTargetId : "");
+  state.consumableRuntime = {
+    tempHp: Number.isFinite(room.sim.player?.consumableRuntime?.tempHp) ? room.sim.player.consumableRuntime.tempHp : 0
+  };
+  state.color = room.getClientRunColor(client);
+  room.activePlayers.set(client.id, state);
+  return state;
+}
+
+export function createPlayerSimulationContextForRoom(room, state) {
+  if (!state) return null;
+  const context = Object.create(room.sim);
+  context.player = state;
+  context.classType = state.classType;
+  context.classSpec = room.getClassSpec(state.classType);
+  context.level = Number.isFinite(state.level) ? state.level : 1;
+  context.score = Number.isFinite(state.score) ? state.score : 0;
+  context.gold = Number.isFinite(state.gold) ? state.gold : 0;
+  context.experience = Number.isFinite(state.experience) ? state.experience : 0;
+  context.expToNextLevel = Number.isFinite(state.expToNextLevel)
+    ? state.expToNextLevel
+    : room.sim.config?.progression?.baseXpToLevel || 10;
+  context.skillPoints = Number.isFinite(state.skillPoints) ? state.skillPoints : 0;
+  context.refundCount = Number.isFinite(state.refundCount) ? state.refundCount : 0;
+  context.levelWeaponDamageBonus = Number.isFinite(state.levelWeaponDamageBonus) ? state.levelWeaponDamageBonus : 0;
+  context.skills = cloneSkillState(state.skills);
+  context.rangerTalents = cloneRangerTalentState(state.rangerTalents);
+  context.warriorTalents = cloneWarriorTalentState(state.warriorTalents);
+  context.necromancerTalents = cloneNecromancerTalentState(state.necromancerTalents);
+  context.upgrades = cloneUpgradeState(state.upgrades);
+  context.consumables = cloneConsumableInventoryState(state.consumables);
+  context.rangerRuntime = cloneRangerRuntimeState(state.rangerRuntime);
+  context.warriorRuntime = cloneWarriorRuntimeState(state.warriorRuntime);
+  context.necromancerRuntime = cloneNecromancerRuntimeState(state.necromancerRuntime);
+  context.player.consumableRuntime = {
+    tempHp: Number.isFinite(state?.consumableRuntime?.tempHp) ? state.consumableRuntime.tempHp : 0
+  };
+  context.warriorMomentumTimer = Number.isFinite(state.warriorMomentumTimer) ? state.warriorMomentumTimer : 0;
+  context.warriorRageActiveTimer = Number.isFinite(state.warriorRageActiveTimer) ? state.warriorRageActiveTimer : 0;
+  context.warriorRageCooldownTimer = Number.isFinite(state.warriorRageCooldownTimer) ? state.warriorRageCooldownTimer : 0;
+  context.warriorRageVictoryRushPool = Number.isFinite(state.warriorRageVictoryRushPool) ? state.warriorRageVictoryRushPool : 0;
+  context.warriorRageVictoryRushTimer = Number.isFinite(state.warriorRageVictoryRushTimer) ? state.warriorRageVictoryRushTimer : 0;
+  context.necromancerBeam = cloneNecromancerBeamState(state.necromancerBeam);
+  context.recordRunGoldSpent = () => {};
+  context.recordClassSpecificStat = () => {};
+  return context;
+}
+
+export function syncActivePlayerStateFromContextForRoom(state, context) {
+  if (!state || !context) return;
+  state.classType = context.classType;
+  state.level = Number.isFinite(context.level) ? context.level : state.level;
+  state.score = Number.isFinite(context.score) ? context.score : state.score;
+  state.gold = Number.isFinite(context.gold) ? context.gold : state.gold;
+  state.experience = Number.isFinite(context.experience) ? context.experience : state.experience;
+  state.expToNextLevel = Number.isFinite(context.expToNextLevel) ? context.expToNextLevel : state.expToNextLevel;
+  state.skillPoints = Number.isFinite(context.skillPoints) ? context.skillPoints : state.skillPoints;
+  state.refundCount = Number.isFinite(context.refundCount) ? context.refundCount : state.refundCount;
+  state.levelWeaponDamageBonus = Number.isFinite(context.levelWeaponDamageBonus)
+    ? context.levelWeaponDamageBonus
+    : state.levelWeaponDamageBonus;
+  state.skills = cloneSkillState(context.skills);
+  state.rangerTalents = cloneRangerTalentState(context.rangerTalents);
+  state.warriorTalents = cloneWarriorTalentState(context.warriorTalents);
+  state.necromancerTalents = cloneNecromancerTalentState(context.necromancerTalents);
+  state.upgrades = cloneUpgradeState(context.upgrades);
+  state.consumables = cloneConsumableInventoryState(context.consumables);
+  state.rangerRuntime = cloneRangerRuntimeState(context.rangerRuntime);
+  state.warriorRuntime = cloneWarriorRuntimeState(context.warriorRuntime);
+  state.necromancerRuntime = cloneNecromancerRuntimeState(context.necromancerRuntime);
+  state.consumableRuntime = {
+    tempHp: Number.isFinite(context?.player?.consumableRuntime?.tempHp) ? context.player.consumableRuntime.tempHp : 0
+  };
+  state.warriorMomentumTimer = Number.isFinite(context.warriorMomentumTimer) ? context.warriorMomentumTimer : 0;
+  state.warriorRageActiveTimer = Number.isFinite(context.warriorRageActiveTimer) ? context.warriorRageActiveTimer : 0;
+  state.warriorRageCooldownTimer = Number.isFinite(context.warriorRageCooldownTimer) ? context.warriorRageCooldownTimer : 0;
+  state.warriorRageVictoryRushPool = Number.isFinite(context.warriorRageVictoryRushPool) ? context.warriorRageVictoryRushPool : 0;
+  state.warriorRageVictoryRushTimer = Number.isFinite(context.warriorRageVictoryRushTimer) ? context.warriorRageVictoryRushTimer : 0;
+  state.necromancerBeam = cloneNecromancerBeamState(context.necromancerBeam);
+  if (typeof context.getPlayerMoveSpeed === "function") state.speed = context.getPlayerMoveSpeed();
+}

--- a/server/net/clientInputQueue.js
+++ b/server/net/clientInputQueue.js
@@ -1,0 +1,57 @@
+const MAX_INPUT_QUEUE_DEPTH = 96;
+
+function finiteSeq(value) {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+export function resetClientInputState(client, makeDefaultInput) {
+  if (!client) return;
+  client.input = typeof makeDefaultInput === "function" ? makeDefaultInput() : { seq: 0 };
+  client.inputQueue = [];
+  client.lastInputSeq = 0;
+  client.lastReceivedInputSeq = 0;
+  client.lastProcessedInputSeq = 0;
+  client.droppedInputCount = 0;
+}
+
+export function enqueueClientInput(client, rawInput, { sanitizeInput }) {
+  if (!client || typeof sanitizeInput !== "function") return false;
+  if (!Array.isArray(client.inputQueue)) client.inputQueue = [];
+  const previous = client.inputQueue.length > 0
+    ? client.inputQueue[client.inputQueue.length - 1]
+    : client.input;
+  const input = sanitizeInput(rawInput, previous);
+  const seq = finiteSeq(input.seq);
+  if (seq <= finiteSeq(client.lastReceivedInputSeq)) return false;
+  input.seq = seq;
+  client.inputQueue.push(input);
+  client.lastInputSeq = seq;
+  client.lastReceivedInputSeq = seq;
+  if (client.inputQueue.length > MAX_INPUT_QUEUE_DEPTH) {
+    const dropCount = client.inputQueue.length - MAX_INPUT_QUEUE_DEPTH;
+    client.inputQueue.splice(0, dropCount);
+    client.droppedInputCount = finiteSeq(client.droppedInputCount) + dropCount;
+  }
+  return true;
+}
+
+export function promoteQueuedClientInput(client) {
+  if (!client || !Array.isArray(client.inputQueue) || client.inputQueue.length === 0) return false;
+  const input = client.inputQueue[client.inputQueue.length - 1];
+  client.input = { ...input };
+  client.lastProcessedInputSeq = finiteSeq(input.seq);
+  client.inputQueue.length = 0;
+  return true;
+}
+
+export function getProcessedInputSeq(client) {
+  return finiteSeq(client?.lastProcessedInputSeq);
+}
+
+export function getReceivedInputSeq(client) {
+  return finiteSeq(client?.lastReceivedInputSeq ?? client?.lastInputSeq);
+}
+
+export function getInputQueueDepth(client) {
+  return Array.isArray(client?.inputQueue) ? client.inputQueue.length : 0;
+}

--- a/server/net/clientMessageHandler.js
+++ b/server/net/clientMessageHandler.js
@@ -1,4 +1,5 @@
 import { normalizeBoardType, sanitizeHandle } from "../leaderboardStore.js";
+import { enqueueClientInput, getProcessedInputSeq } from "./clientInputQueue.js";
 
 export function handleActionMessage(room, clientId, action) {
   if (!action || typeof action !== "object" || typeof action.kind !== "string") return;
@@ -180,6 +181,7 @@ export function handleClientMessage(raw, context) {
     normClassType,
     maxPeersPerRoom,
     makeDefaultInput,
+    resetClientInputState,
     sanitizeInput,
     serializeState,
     buildJoinKeyframeState,
@@ -255,7 +257,8 @@ export function handleClientMessage(raw, context) {
     client.classType = classType;
     client.protocolVersion =
       Number.isFinite(msg.protocolVersion) && msg.protocolVersion >= 1 ? Math.floor(msg.protocolVersion) : client.protocolVersion;
-    client.input = makeDefaultInput();
+    if (typeof resetClientInputState === "function") resetClientInputState(client, makeDefaultInput);
+    else client.input = makeDefaultInput();
     room.addClient(client);
 
     safeSend(ws, {
@@ -285,8 +288,10 @@ export function handleClientMessage(raw, context) {
         ownerId: room.roomOwnerId,
         pauseOwnerId: room.pauseOwnerId,
         controllerId: room.controllerId,
-        lastInputSeq: room.clients.get(room.controllerId)?.lastInputSeq || 0,
+        lastInputSeq: getProcessedInputSeq(room.clients.get(room.controllerId)),
         lastInputSeqByPlayer: room.getLastInputSeqByPlayer(),
+        lastReceivedInputSeqByPlayer: room.getLastReceivedInputSeqByPlayer(),
+        inputQueueDepthByPlayer: room.getInputQueueDepthByPlayer(),
         mapSignature: room.mapSignature(),
         state: joinState
       });
@@ -300,8 +305,7 @@ export function handleClientMessage(raw, context) {
     if (!client.roomId || !rooms.has(client.roomId)) return;
     const room = rooms.get(client.roomId);
     if (room.phase !== "active") return;
-    client.input = sanitizeInput(msg.input, client.input);
-    client.lastInputSeq = client.input.seq || client.lastInputSeq;
+    enqueueClientInput(client, msg.input, { sanitizeInput });
     return;
   }
 

--- a/server/net/deltaProtocol.js
+++ b/server/net/deltaProtocol.js
@@ -6,10 +6,11 @@ function shallowCloneEntry(entry) {
 function pickChangedFields(prev, next) {
   const patch = {};
   let changed = false;
-  for (const key of Object.keys(next)) {
+  const keys = new Set([...Object.keys(prev || {}), ...Object.keys(next || {})]);
+  for (const key of keys) {
     if (key === "id") continue;
     if (prev[key] !== next[key]) {
-      patch[key] = next[key];
+      patch[key] = Object.prototype.hasOwnProperty.call(next, key) ? next[key] : null;
       changed = true;
     }
   }

--- a/server/net/stateSerialization.js
+++ b/server/net/stateSerialization.js
@@ -28,6 +28,24 @@ export function getStableId(room, domain, prefix, obj) {
   return id;
 }
 
+function copyFiniteFields(payload, source, fields) {
+  for (const field of fields) {
+    if (Number.isFinite(source?.[field])) payload[field] = source[field];
+  }
+}
+
+function copyStringFields(payload, source, fields) {
+  for (const field of fields) {
+    if (typeof source?.[field] === "string" && source[field]) payload[field] = source[field];
+  }
+}
+
+function copyBooleanFields(payload, source, fields) {
+  for (const field of fields) {
+    if (typeof source?.[field] === "boolean") payload[field] = source[field];
+  }
+}
+
 function serializeBullet(room, b, domain = "bullet", prefix = "b") {
   const payload = {
     id: getStableId(room, domain, prefix, b),
@@ -47,6 +65,45 @@ function serializeBullet(room, b, domain = "bullet", prefix = "b") {
   if (Number.isFinite(b.lightRadius)) payload.lightRadius = b.lightRadius;
   if (Number.isFinite(b.lightIntensity)) payload.lightIntensity = b.lightIntensity;
   if (typeof b.projectileType === "string" && b.projectileType !== "bullet") payload.projectileType = b.projectileType;
+  copyStringFields(payload, b, ["damageType"]);
+  copyFiniteFields(payload, b, ["critMultiplier", "visualLife", "deathBoltRadius"]);
+  return payload;
+}
+
+function serializeFireZone(room, z) {
+  const payload = {
+    id: getStableId(room, "fireZone", "fz", z),
+    x: z.x,
+    y: z.y,
+    targetX: z.targetX,
+    targetY: z.targetY,
+    radius: z.radius,
+    lightRadius: z.lightRadius,
+    lightIntensity: z.lightIntensity,
+    life: z.life,
+    totalLife: z.totalLife,
+    zoneType: typeof z.zoneType === "string" ? z.zoneType : "fire",
+    damageType: typeof z.damageType === "string" ? z.damageType : ""
+  };
+  copyStringFields(payload, z, ["doctrine", "ownerId"]);
+  copyFiniteFields(payload, z, ["size", "strikeAt", "visualLife"]);
+  copyBooleanFields(payload, z, ["followOwner"]);
+  return payload;
+}
+
+function serializeMeleeSwing(room, s) {
+  const payload = {
+    id: getStableId(room, "meleeSwing", "ms", s),
+    x: s.x,
+    y: s.y,
+    angle: s.angle,
+    arc: s.arc,
+    range: s.range,
+    life: s.life
+  };
+  copyStringFields(payload, s, ["style", "modifier", "doctrine", "ownerId"]);
+  copyFiniteFields(payload, s, ["maxLife"]);
+  copyBooleanFields(payload, s, ["executeProc"]);
   return payload;
 }
 
@@ -294,28 +351,7 @@ export function serializeState(room) {
     wallTraps: activeWallTraps.map((t) => serializeWallTrap(room, t)),
     bullets: activeBullets.map((b) => serializeBullet(room, b, "bullet", "b")),
     fireArrows: activeFireArrows.map((a) => serializeBullet(room, a, "fireArrow", "fa")),
-    fireZones: activeFireZones.map((z) => ({
-      id: getStableId(room, "fireZone", "fz", z),
-      x: z.x,
-      y: z.y,
-      targetX: z.targetX,
-      targetY: z.targetY,
-      radius: z.radius,
-      lightRadius: z.lightRadius,
-      lightIntensity: z.lightIntensity,
-      life: z.life,
-      totalLife: z.totalLife,
-      zoneType: typeof z.zoneType === "string" ? z.zoneType : "fire",
-      damageType: typeof z.damageType === "string" ? z.damageType : ""
-    })),
-    meleeSwings: activeMeleeSwings.map((s) => ({
-      id: getStableId(room, "meleeSwing", "ms", s),
-      x: s.x,
-      y: s.y,
-      angle: s.angle,
-      arc: s.arc,
-      range: s.range,
-      life: s.life
-    }))
+    fireZones: activeFireZones.map((z) => serializeFireZone(room, z)),
+    meleeSwings: activeMeleeSwings.map((s) => serializeMeleeSwing(room, s))
   };
 }

--- a/server/net/stateSerialization.js
+++ b/server/net/stateSerialization.js
@@ -1,93 +1,4 @@
-function shallowPlayerState(simPlayer) {
-  return {
-    x: simPlayer.x,
-    y: simPlayer.y,
-    size: simPlayer.size,
-    health: simPlayer.health,
-    maxHealth: simPlayer.maxHealth,
-    hpBarTimer: simPlayer.hpBarTimer || 0,
-    level: simPlayer.level,
-    score: simPlayer.score,
-    gold: simPlayer.gold,
-    experience: simPlayer.experience,
-    expToNextLevel: simPlayer.expToNextLevel,
-    skillPoints: simPlayer.skillPoints,
-    refundCount: simPlayer.refundCount,
-    levelWeaponDamageBonus: simPlayer.levelWeaponDamageBonus,
-    lanternFuel: simPlayer.lanternFuel,
-    skills: simPlayer.skills,
-    rangerTalents: simPlayer.rangerTalents,
-    warriorTalents: simPlayer.warriorTalents,
-    necromancerTalents: simPlayer.necromancerTalents,
-    rangerRuntime: simPlayer.rangerRuntime,
-    warriorRuntime: simPlayer.warriorRuntime,
-    necromancerRuntime: simPlayer.necromancerRuntime,
-    consumableRuntime: simPlayer.consumableRuntime,
-    consumables: simPlayer.consumables,
-    upgrades: simPlayer.upgrades,
-    dirX: simPlayer.dirX,
-    dirY: simPlayer.dirY,
-    facing: simPlayer.facing,
-    classType: simPlayer.classType
-  };
-}
-
-function shallowActivePlayerState(player) {
-  return {
-    id: player.id,
-    handle: player.handle,
-    classType: player.classType,
-    x: player.x,
-    y: player.y,
-    size: player.size,
-    health: player.health,
-    maxHealth: player.maxHealth,
-    hpBarTimer: player.hpBarTimer || 0,
-    level: player.level,
-    score: player.score,
-    gold: player.gold,
-    experience: player.experience,
-    expToNextLevel: player.expToNextLevel,
-    skillPoints: player.skillPoints,
-    refundCount: player.refundCount,
-    levelWeaponDamageBonus: player.levelWeaponDamageBonus,
-    lanternFuel: player.lanternFuel,
-    fireCooldown: player.fireCooldown,
-    fireArrowCooldown: player.fireArrowCooldown,
-    deathBoltCooldown: player.deathBoltCooldown,
-    warriorMomentumTimer: player.warriorMomentumTimer,
-    warriorRageActiveTimer: player.warriorRageActiveTimer,
-    warriorRageCooldownTimer: player.warriorRageCooldownTimer,
-    warriorRageVictoryRushPool: player.warriorRageVictoryRushPool,
-    warriorRageVictoryRushTimer: player.warriorRageVictoryRushTimer,
-    necromancerBeam: player.necromancerBeam
-      ? {
-          active: !!player.necromancerBeam.active,
-          targetId: typeof player.necromancerBeam.targetId === "string" ? player.necromancerBeam.targetId : null,
-          targetX: Number.isFinite(player.necromancerBeam.targetX) ? player.necromancerBeam.targetX : 0,
-          targetY: Number.isFinite(player.necromancerBeam.targetY) ? player.necromancerBeam.targetY : 0,
-          progress: Number.isFinite(player.necromancerBeam.progress) ? player.necromancerBeam.progress : 0
-        }
-      : null,
-    skills: player.skills,
-    rangerTalents: player.rangerTalents,
-    warriorTalents: player.warriorTalents,
-    necromancerTalents: player.necromancerTalents,
-    upgrades: player.upgrades,
-    consumableRuntime: player.consumableRuntime,
-    consumables: player.consumables,
-    rangerRuntime: player.rangerRuntime,
-    warriorRuntime: player.warriorRuntime,
-    necromancerRuntime: player.necromancerRuntime,
-    dirX: player.dirX,
-    dirY: player.dirY,
-    facing: player.facing,
-    moving: !!player.moving,
-    alive: player.alive !== false,
-    spectateTargetId: typeof player.spectateTargetId === "string" ? player.spectateTargetId : "",
-    color: player.color
-  };
-}
+import { createActivePlayerSnapshot, createPlayerSnapshot } from "../../src/net/playerSnapshotSchema.js";
 
 function resolveControlledEnemyColor(room, enemy) {
   const ownerId = typeof enemy?.controllerPlayerId === "string" && enemy.controllerPlayerId ? enemy.controllerPlayerId : null;
@@ -371,8 +282,8 @@ export function serializeState(room) {
     floor: sim.floor,
     biomeKey: sim.biomeKey,
     floorBoss,
-    player: shallowPlayerState(primaryPlayer),
-    players: activePlayers.map((player) => shallowActivePlayerState(player)),
+    player: createPlayerSnapshot(primaryPlayer),
+    players: activePlayers.map((player) => createActivePlayerSnapshot(player)),
     door: { ...sim.door },
     pickup: { ...sim.pickup },
     portal: sim.portal ? { ...sim.portal } : null,

--- a/server/net/stateSerialization.js
+++ b/server/net/stateSerialization.js
@@ -153,6 +153,13 @@ function serializeEnemy(room, e) {
     case "treasure_goblin":
       base.goldEaten = e.goldEaten || 0;
       break;
+    case "mimic":
+      base.dormant = !!e.dormant;
+      base.revealed = !!e.revealed;
+      base.tongueDirX = e.tongueDirX;
+      base.tongueDirY = e.tongueDirY;
+      base.tongueLength = e.tongueLength || 0;
+      break;
     default:
       break;
   }

--- a/server/networkServer.js
+++ b/server/networkServer.js
@@ -16,6 +16,7 @@ import { handleLeaderboardApiRequest } from "./leaderboardApi.js";
 import { LeaderboardStore } from "./leaderboardStore.js";
 import { handleDevNetworkTelemetryRequest } from "./devNetworkTelemetryApi.js";
 import { buildAgoraVoiceUid, buildVoiceClientConfig, buildVoiceRoomConfig, resolveVoiceConfig } from "./net/voiceConfig.js";
+import { resetClientInputState } from "./net/clientInputQueue.js";
 
 const PORT = Number.parseInt(process.env.PORT || "8090", 10);
 const HOST = typeof process.env.HOST === "string" && process.env.HOST.trim() ? process.env.HOST.trim() : "";
@@ -111,8 +112,13 @@ wss.on("connection", (ws) => {
     classType: "archer",
     protocolVersion: 1,
     input: makeDefaultInput(),
-    lastInputSeq: 0
+    inputQueue: [],
+    lastInputSeq: 0,
+    lastReceivedInputSeq: 0,
+    lastProcessedInputSeq: 0,
+    droppedInputCount: 0
   };
+  resetClientInputState(client, makeDefaultInput);
 
   safeSend(transport, {
     type: "hello",
@@ -132,6 +138,7 @@ wss.on("connection", (ws) => {
       normClassType,
       maxPeersPerRoom: MAX_PEERS_PER_ROOM,
       makeDefaultInput,
+      resetClientInputState,
       sanitizeInput,
       serializeState,
       buildJoinKeyframeState,

--- a/server/run-validation-suite.js
+++ b/server/run-validation-suite.js
@@ -38,6 +38,7 @@ const SCRIPT_TARGETS = {
   "validate:network-controller": "server/validate-network-controller-responsiveness.js",
   "validate:network-projectiles": "server/validate-network-projectile-prediction.js",
   "validate:network-smoothness": "server/validate-network-smoothness.js",
+  "validate:network-state-corruption": "server/validate-network-state-corruption.js",
   "validate:mobile-transport": "server/validate-mobile-transport-defaults.js",
   "validate:network-framework": "server/validate-network-framework-evaluation.js",
   "validate:selective-closeout-plan": "server/validate-selective-closeout-plan.js",
@@ -79,6 +80,7 @@ const SUITES = {
     "validate:network-controller",
     "validate:network-projectiles",
     "validate:network-smoothness",
+    "validate:network-state-corruption",
     "validate:network-join",
     "validate:network-combat-hit",
     "validate:network-archer"

--- a/server/validate-dev-network-telemetry.js
+++ b/server/validate-dev-network-telemetry.js
@@ -93,6 +93,51 @@ async function main() {
           floor: 1,
           projectileReconcileRejects: 1,
           projectileReconcileRejectDelta: 1,
+          networkStateAnomalyEventId: 5,
+          recentStateAnomalies: [
+            {
+              id: 4,
+              atMs: 940,
+              kind: "enemyStatusFanout",
+              keyframe: true,
+              ackSeq: 12,
+              enemyCount: 6,
+              tripleStatusCount: 5,
+              fullHpBarCount: 5,
+              localMimicTimer: 0,
+              remoteMimicCount: 0,
+              remotePlayerIds: []
+            },
+            {
+              id: 5,
+              atMs: 980,
+              kind: "playerMimicRuntimeVisible",
+              keyframe: false,
+              ackSeq: 13,
+              enemyCount: null,
+              tripleStatusCount: null,
+              fullHpBarCount: null,
+              localMimicTimer: 0,
+              remoteMimicCount: 1,
+              remotePlayerIds: ["owner"]
+            }
+          ],
+          serverStateAnomalyEventId: 7,
+          recentServerStateAnomalies: [
+            {
+              id: 7,
+              atMs: 990,
+              snapshotSeq: 44,
+              kind: "enemyStatusFanout",
+              paused: false,
+              context: { source: "activePlayerAction", playerId: "owner" },
+              enemyCount: 6,
+              tripleStatusCount: 5,
+              tripleStatusEnemies: [{ id: "e_1", burningTimer: 1, curseTimer: 1, rotTimer: 1 }],
+              mimicPlayers: [],
+              classMismatches: []
+            }
+          ],
           recentProjectileReconcileRejects: [{
             id: 3,
             atMs: 975,
@@ -180,6 +225,17 @@ async function main() {
     assert.equal(sample.recentProjectileReconcileRejects[0].bucketSeq, 41, "projectile reject should preserve predicted bucket seq");
     assert.equal(sample.recentProjectileReconcileRejects[0].distancePx, 72.25, "projectile reject should preserve distance");
     assert.equal(sample.recentProjectileReconcileRejects[0].maxDistancePx, 48, "projectile reject should preserve max distance");
+    assert.equal(sample.networkStateAnomalyEventId, 5, "sample should preserve network state anomaly event id");
+    assert.equal(sample.recentStateAnomalies?.length, 2, "sample should preserve recent state anomaly events");
+    assert.equal(sample.recentStateAnomalies[0].kind, "enemyStatusFanout", "state anomaly should preserve enemy status kind");
+    assert.equal(sample.recentStateAnomalies[0].tripleStatusCount, 5, "state anomaly should preserve triple status count");
+    assert.equal(sample.recentStateAnomalies[1].kind, "playerMimicRuntimeVisible", "state anomaly should preserve player mimic kind");
+    assert.equal(sample.recentStateAnomalies[1].remoteMimicCount, 1, "state anomaly should preserve remote mimic count");
+    assert.deepEqual(sample.recentStateAnomalies[1].remotePlayerIds, ["owner"], "state anomaly should preserve remote player ids");
+    assert.equal(sample.serverStateAnomalyEventId, 7, "sample should preserve server state anomaly event id");
+    assert.equal(sample.recentServerStateAnomalies?.length, 1, "sample should preserve server state anomalies");
+    assert.equal(sample.recentServerStateAnomalies[0].context?.source, "activePlayerAction", "server anomaly should preserve source context");
+    assert.equal(sample.recentServerStateAnomalies[0].tripleStatusEnemies?.[0]?.id, "e_1", "server anomaly should preserve enemy samples");
     assert.equal(sample.renderContext?.rendererMode, "canvas2d", "sample should preserve renderer mode");
     assert.equal(sample.renderContext?.devicePixelRatio, 1.25, "sample should preserve device pixel ratio");
     assert.equal(sample.renderContext?.visualViewportWidth, 1280, "sample should preserve visual viewport width");

--- a/server/validate-network-pause.js
+++ b/server/validate-network-pause.js
@@ -227,6 +227,10 @@ async function main() {
 
     await ownerPage.keyboard.press("Escape");
 
+    await ownerPage.waitForFunction(() => {
+      const state = window.__WOTC_DEBUG__?.getState?.();
+      return !!state && state.ui?.paused === false && state.ui?.shopOpen === false;
+    }, { timeout: 5000 });
     await otherPage.waitForFunction(() => {
       const state = window.__WOTC_DEBUG__?.getState?.();
       return !!state && state.ui?.paused === false;

--- a/server/validate-network-rubberband-soak.js
+++ b/server/validate-network-rubberband-soak.js
@@ -1,0 +1,266 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import process from "node:process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { chromium } from "playwright";
+import {
+  capturePageFailure,
+  choosePythonCommand,
+  ensurePortAvailable,
+  getDebugState,
+  startChild,
+  stopChildren,
+  waitForHttpReady,
+  waitForTcpReady
+} from "./validation/networkValidationShared.js";
+import { runBots } from "./bots/run-player-bots.js";
+
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const artifactsDir = resolve(projectRoot, "artifacts", "network");
+const HTTP_PORT = Number.parseInt(process.env.HTTP_PORT || "8212", 10);
+const WS_PORT = Number.parseInt(process.env.WS_PORT || "8213", 10);
+const ROOM_ID = "validate-network-rubberband-soak";
+const GAME_URL = `http://127.0.0.1:${HTTP_PORT}`;
+const BOT_COUNT = 5;
+const BOT_DURATION_SECONDS = 18;
+const children = [];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function percentile(values, pct) {
+  const sorted = values.filter(Number.isFinite).slice().sort((a, b) => a - b);
+  if (sorted.length === 0) return 0;
+  const idx = Math.max(0, Math.min(sorted.length - 1, Math.ceil((pct / 100) * sorted.length) - 1));
+  return sorted[idx];
+}
+
+function summarizeSamples(samples) {
+  const frameGaps = [];
+  const movementSteps = [];
+  const pendingInputs = [];
+  const flightEvents = new Map();
+  let travelled = 0;
+  let firstMovementAtMs = null;
+  const start = samples[0] || null;
+  for (let i = 1; i < samples.length; i++) {
+    const prev = samples[i - 1];
+    const next = samples[i];
+    frameGaps.push(next.t - prev.t);
+    const dist = Math.hypot(next.x - prev.x, next.y - prev.y);
+    movementSteps.push(dist);
+    travelled += dist;
+    if (firstMovementAtMs === null && start && Math.hypot(next.x - start.x, next.y - start.y) >= 1.5) firstMovementAtMs = next.t;
+  }
+  for (const sample of samples) {
+    if (Number.isFinite(sample.pendingInputs)) pendingInputs.push(sample.pendingInputs);
+    for (const event of sample.flightEvents || []) {
+      if (event?.id != null) flightEvents.set(event.id, event);
+    }
+  }
+  const events = Array.from(flightEvents.values());
+  const postLoadEvents = events.filter((event) => event.controller && event.postLoadActive === true);
+  return {
+    frames: samples.length,
+    travelled,
+    firstMovementAtMs,
+    frameGapP95: percentile(frameGaps, 95),
+    frameGapMax: Math.max(0, ...frameGaps),
+    movementStepP95: percentile(movementSteps, 95),
+    movementStepMax: Math.max(0, ...movementSteps),
+    pendingInputMax: Math.max(0, ...pendingInputs),
+    snapshotCountMax: Math.max(0, ...samples.map((sample) => sample.snapshotCount || 0)),
+    correctionMax: Math.max(0, ...samples.map((sample) => sample.maxCorrectionPx || 0)),
+    postLoadCorrectionMax: Math.max(0, ...samples.map((sample) => sample.postLoadMaxCorrectionPx || 0)),
+    postLoadHardSnapMax: Math.max(0, ...samples.map((sample) => sample.postLoadHardSnapCount || 0)),
+    blockedSnapMax: Math.max(0, ...samples.map((sample) => sample.blockedSnapCount || 0)),
+    flightEventCount: events.length,
+    postLoadFlightEventCount: postLoadEvents.length,
+    flightHardSnapCount: postLoadEvents.filter((event) => event.correctionKind === "hardSnap" || event.correctionKind === "blockedHardSnap").length,
+    flightCorrectionP95: percentile(postLoadEvents.map((event) => event.correctionPx || 0), 95),
+    flightAppliedP95: percentile(postLoadEvents.map((event) => event.appliedPx || 0), 95),
+    flightPendingMax: Math.max(0, ...postLoadEvents.map((event) => event.pendingInputs || 0)),
+    lastEvents: events.slice(-12)
+  };
+}
+
+async function openLobby(page, { wsUrl, roomId, playerName, classType }) {
+  await page.goto(GAME_URL, { waitUntil: "networkidle" });
+  await page.keyboard.press("Space");
+  await page.locator("#mode-select").waitFor({ state: "visible", timeout: 10000 });
+  await page.locator("#menu-network").click();
+  await page.locator("#network-setup-screen").waitFor({ state: "visible", timeout: 10000 });
+  await page.locator("#net-server-url").fill(wsUrl);
+  await page.locator("#net-room-id").fill(roomId);
+  await page.locator("#net-player-name-setup").fill(playerName);
+  await page.locator("#network-setup-next").click();
+  await page.locator("#network-lobby-screen").waitFor({ state: "visible", timeout: 10000 });
+  await page.locator(`[data-lobby-class-option="${classType}"]`).click();
+}
+
+async function waitForActive(page, timeoutMs = 30000) {
+  await page.waitForFunction(() => {
+    const state = window.__WOTC_DEBUG__?.getState?.();
+    return !!state && state.networkReady === true && state.networkRole === "Active";
+  }, { timeout: timeoutMs });
+  return getDebugState(page);
+}
+
+async function waitForRoster(page, expectedCount, timeoutMs = 15000) {
+  await page.waitForFunction((count) => {
+    const items = Array.from(document.querySelectorAll("#network-lobby-roster .network-lobby-roster-entry"));
+    return items.length >= count;
+  }, expectedCount, { timeout: timeoutMs });
+}
+
+async function samplePlayerFrames(page, durationMs) {
+  return page.evaluate((duration) => new Promise((resolve) => {
+    const samples = [];
+    const startedAt = performance.now();
+    const tick = () => {
+      const state = window.__WOTC_DEBUG__?.getState?.();
+      if (state?.player) {
+        samples.push({
+          t: performance.now() - startedAt,
+          x: state.player.x,
+          y: state.player.y,
+          snapshotCount: state.networkPerf?.appliedSnapshotCount || 0,
+          pendingInputs: state.net?.pendingInputs || 0,
+          maxCorrectionPx: state.networkPerf?.maxCorrectionPx || 0,
+          postLoadMaxCorrectionPx: state.networkPerf?.postLoadMaxCorrectionPx || 0,
+          postLoadHardSnapCount: state.networkPerf?.postLoadHardSnapCount || 0,
+          blockedSnapCount: state.networkPerf?.blockedSnapCount || 0,
+          flightEvents: Array.isArray(state.networkPerf?.recentFlightEvents) ? state.networkPerf.recentFlightEvents.slice(-24) : []
+        });
+      }
+      if (performance.now() - startedAt >= duration) resolve(samples);
+      else requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }), durationMs);
+}
+
+async function sampleBestMovement(page, durationMs, minTravelPx) {
+  const attempts = [];
+  for (const key of ["d", "s", "a", "w"]) {
+    await page.keyboard.down(key);
+    let frames = [];
+    try {
+      frames = await samplePlayerFrames(page, durationMs);
+    } finally {
+      await page.keyboard.up(key);
+    }
+    const summary = summarizeSamples(frames);
+    attempts.push({ key, summary, frames: frames.slice(0, 16) });
+    if (summary.travelled >= minTravelPx) return { key, frames, summary, attempts };
+    await delay(160);
+  }
+  const best = attempts.sort((a, b) => b.summary.travelled - a.summary.travelled)[0] || { key: "", frames: [], summary: summarizeSamples([]) };
+  return { ...best, attempts };
+}
+
+async function captureFailure(page, error, details = null) {
+  const state = await getDebugState(page).catch(() => null);
+  return capturePageFailure(
+    page,
+    {
+      dir: artifactsDir,
+      screenshotPath: resolve(artifactsDir, "validate-network-rubberband-soak-failure.png"),
+      statePath: resolve(artifactsDir, "validate-network-rubberband-soak-failure.json")
+    },
+    error,
+    state,
+    details
+  );
+}
+
+async function main() {
+  await ensurePortAvailable(HTTP_PORT, "HTTP");
+  await ensurePortAvailable(WS_PORT, "WS");
+  const python = choosePythonCommand();
+  startChild(children, projectRoot, "http", python.cmd, [...python.args, String(HTTP_PORT)]);
+  startChild(children, projectRoot, "ws", process.execPath, ["server/networkServer.js"], {
+    PORT: String(WS_PORT),
+    SNAPSHOT_RATE: "20",
+    TICK_RATE: "60"
+  });
+  await waitForHttpReady(GAME_URL);
+  await waitForTcpReady(WS_PORT);
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  const wsUrl = `ws://127.0.0.1:${WS_PORT}`;
+  let botResult = null;
+  const details = {};
+
+  try {
+    await openLobby(page, {
+      wsUrl,
+      roomId: ROOM_ID,
+      playerName: "SoakController",
+      classType: "archer"
+    });
+    const botRun = runBots({
+      url: wsUrl,
+      room: ROOM_ID,
+      bots: BOT_COUNT,
+      duration: BOT_DURATION_SECONDS,
+      seed: "validate-network-rubberband-soak",
+      namePrefix: "SoakBot",
+      staggerMs: 80,
+      logLevel: "silent"
+    });
+    await waitForRoster(page, BOT_COUNT + 1);
+    await page.locator("#network-lobby-toggle-ready").click();
+    await waitForActive(page);
+    await delay(900);
+
+    const first = await sampleBestMovement(page, 1700, 90);
+    const second = await sampleBestMovement(page, 1700, 90);
+    const flightDump = await page.evaluate(() => window.__WOTC_DEBUG__?.run?.("dumpNetworkFlightRecorder") || null);
+    botResult = await botRun;
+
+    details.firstMovement = { key: first.key, summary: first.summary, attempts: first.attempts };
+    details.secondMovement = { key: second.key, summary: second.summary, attempts: second.attempts };
+    details.flightDump = flightDump;
+    details.botTotals = botResult.totals;
+
+    const combined = summarizeSamples([...first.frames, ...second.frames]);
+    assert(botResult.totals.joined === BOT_COUNT, `expected ${BOT_COUNT} bots joined, got ${botResult.totals.joined}`);
+    assert(botResult.totals.started === BOT_COUNT, `expected ${BOT_COUNT} bots started, got ${botResult.totals.started}`);
+    assert(botResult.totals.errors === 0, `bot/server protocol errors: ${botResult.totals.errors}`);
+    assert(combined.frames >= 20, `not enough client frame samples: ${combined.frames}`);
+    assert(combined.travelled >= 160, `controller travelled too little during soak: ${combined.travelled.toFixed(1)}px`);
+    assert(combined.snapshotCountMax >= 18, `too few snapshots applied during soak: ${combined.snapshotCountMax}`);
+    assert(combined.flightEventCount >= 18, `too few flight-recorder events: ${combined.flightEventCount}`);
+    assert(combined.flightPendingMax <= 36, `pending input backlog too high: ${combined.flightPendingMax}`);
+    assert(combined.pendingInputMax <= 42, `sampled pending input backlog too high: ${combined.pendingInputMax}`);
+    assert(combined.postLoadHardSnapMax === 0, `post-load hard snaps exceeded budget: ${combined.postLoadHardSnapMax}`);
+    assert(combined.blockedSnapMax === 0, `blocked correction snaps exceeded budget: ${combined.blockedSnapMax}`);
+    assert(combined.flightHardSnapCount === 0, `flight recorder captured post-load hard snaps: ${combined.flightHardSnapCount}`);
+    assert(combined.flightCorrectionP95 <= 42, `flight correction p95 ${combined.flightCorrectionP95.toFixed(1)}px is too high`);
+    assert(combined.flightAppliedP95 <= 12, `applied correction p95 ${combined.flightAppliedP95.toFixed(1)}px is too high`);
+    assert(combined.movementStepP95 <= 18, `movement step p95 ${combined.movementStepP95.toFixed(1)}px is too high`);
+    assert(combined.movementStepMax <= 44, `movement max step ${combined.movementStepMax.toFixed(1)}px is too high`);
+
+    mkdirSync(artifactsDir, { recursive: true });
+    const successPath = resolve(artifactsDir, "validate-network-rubberband-soak-success.json");
+    writeFileSync(successPath, JSON.stringify({ combined, details, botResult }, null, 2));
+    console.log(JSON.stringify({ combined, botTotals: botResult.totals, successPath }, null, 2));
+  } catch (error) {
+    const artifacts = await captureFailure(page, error, details);
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\nArtifacts: ${artifacts.screenshotPath}, ${artifacts.statePath}`);
+  } finally {
+    await browser.close();
+    stopChildren(children);
+  }
+}
+
+main().catch((error) => {
+  stopChildren(children);
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/server/validate-network-rubberband-soak.js
+++ b/server/validate-network-rubberband-soak.js
@@ -37,27 +37,32 @@ function percentile(values, pct) {
   return sorted[idx];
 }
 
-function summarizeSamples(samples) {
+function summarizeSampleGroups(groups) {
   const frameGaps = [];
   const movementSteps = [];
   const pendingInputs = [];
   const flightEvents = new Map();
   let travelled = 0;
   let firstMovementAtMs = null;
-  const start = samples[0] || null;
-  for (let i = 1; i < samples.length; i++) {
-    const prev = samples[i - 1];
-    const next = samples[i];
-    frameGaps.push(next.t - prev.t);
-    const dist = Math.hypot(next.x - prev.x, next.y - prev.y);
-    movementSteps.push(dist);
-    travelled += dist;
-    if (firstMovementAtMs === null && start && Math.hypot(next.x - start.x, next.y - start.y) >= 1.5) firstMovementAtMs = next.t;
-  }
-  for (const sample of samples) {
-    if (Number.isFinite(sample.pendingInputs)) pendingInputs.push(sample.pendingInputs);
-    for (const event of sample.flightEvents || []) {
-      if (event?.id != null) flightEvents.set(event.id, event);
+  const samples = [];
+  for (const group of groups) {
+    const list = Array.isArray(group) ? group : [];
+    samples.push(...list);
+    const start = list[0] || null;
+    for (let i = 1; i < list.length; i++) {
+      const prev = list[i - 1];
+      const next = list[i];
+      frameGaps.push(next.t - prev.t);
+      const dist = Math.hypot(next.x - prev.x, next.y - prev.y);
+      movementSteps.push(dist);
+      travelled += dist;
+      if (firstMovementAtMs === null && start && Math.hypot(next.x - start.x, next.y - start.y) >= 1.5) firstMovementAtMs = next.t;
+    }
+    for (const sample of list) {
+      if (Number.isFinite(sample.pendingInputs)) pendingInputs.push(sample.pendingInputs);
+      for (const event of sample.flightEvents || []) {
+        if (event?.id != null) flightEvents.set(event.id, event);
+      }
     }
   }
   const events = Array.from(flightEvents.values());
@@ -84,6 +89,10 @@ function summarizeSamples(samples) {
     flightPendingMax: Math.max(0, ...postLoadEvents.map((event) => event.pendingInputs || 0)),
     lastEvents: events.slice(-12)
   };
+}
+
+function summarizeSamples(samples) {
+  return summarizeSampleGroups([samples]);
 }
 
 async function openLobby(page, { wsUrl, roomId, playerName, classType }) {
@@ -228,7 +237,7 @@ async function main() {
     details.flightDump = flightDump;
     details.botTotals = botResult.totals;
 
-    const combined = summarizeSamples([...first.frames, ...second.frames]);
+    const combined = summarizeSampleGroups([first.frames, second.frames]);
     assert(botResult.totals.joined === BOT_COUNT, `expected ${BOT_COUNT} bots joined, got ${botResult.totals.joined}`);
     assert(botResult.totals.started === BOT_COUNT, `expected ${BOT_COUNT} bots started, got ${botResult.totals.started}`);
     assert(botResult.totals.errors === 0, `bot/server protocol errors: ${botResult.totals.errors}`);

--- a/server/validate-network-state-corruption.js
+++ b/server/validate-network-state-corruption.js
@@ -1,0 +1,309 @@
+import { strict as assert } from "node:assert";
+import { AuthoritativeRoom } from "./net/AuthoritativeRoom.js";
+import { buildDeltaCollection } from "./net/deltaProtocol.js";
+import { buildMapChunkRows } from "./net/mapChunkStreaming.js";
+import { getStableId, serializeMetaState, serializeState } from "./net/stateSerialization.js";
+import { average, monotonicNowMs, percentile } from "./net/telemetry.js";
+import { makeDefaultInput } from "./net/serverHelpers.js";
+import { chooseGameplayTrack } from "./musicCatalog.js";
+import { GameSim } from "../src/sim/GameSim.js";
+import { applySnapshotToGame } from "../src/net/clientStateSync.js";
+import { stepNetworkEnemyPresentation } from "../src/bootstrap/networkRenderRuntime.js";
+
+function createFakeSocket() {
+  return {
+    OPEN: 1,
+    readyState: 1,
+    bufferedAmount: 0,
+    send() {}
+  };
+}
+
+function makeClient(id, name, classType) {
+  return {
+    id,
+    name,
+    classType,
+    protocolVersion: 2,
+    ws: createFakeSocket(),
+    input: makeDefaultInput(),
+    lastInputSeq: 0,
+    classLocked: true
+  };
+}
+
+function createRoomOptions() {
+  return {
+    average,
+    buildDeltaCollection,
+    buildMapChunkRows,
+    chooseGameplayTrack,
+    deltaKeyframeEvery: 30,
+    getStableId,
+    makeDefaultInput,
+    mapChunkPushMs: 120,
+    mapChunkRadius: 2,
+    mapChunkSize: 24,
+    maxWsBufferedBytes: 262144,
+    metaBroadcastMinMs: 320,
+    monotonicNowMs,
+    percentile,
+    pushTelemetrySample() {},
+    serializeMetaState,
+    serializeState,
+    snapshotAckGapForceKeyframe: 8,
+    tickDriftEpsilonMs: 0.5
+  };
+}
+
+function makeStatusEnemy(id, x, y) {
+  return {
+    id,
+    type: "ghost",
+    x,
+    y,
+    size: 20,
+    hp: 10,
+    maxHp: 10,
+    hpBarTimer: 1.2,
+    burningTimer: 1.1,
+    burningDps: 3,
+    curseTimer: 1.3,
+    rotTimer: 1.4,
+    rotDps: 2
+  };
+}
+
+function latestAnomaly(game, kind) {
+  const entries = Array.isArray(game?.networkPerf?.recentStateAnomalies) ? game.networkPerf.recentStateAnomalies : [];
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    if (entries[i]?.kind === kind) return entries[i];
+  }
+  return null;
+}
+
+function latestServerAnomaly(game, kind) {
+  const entries = Array.isArray(game?.networkPerf?.recentServerStateAnomalies)
+    ? game.networkPerf.recentServerStateAnomalies
+    : [];
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    if (entries[i]?.kind === kind) return entries[i];
+  }
+  return null;
+}
+
+function main() {
+  const room = new AuthoritativeRoom("validate-network-state-corruption", "archer", createRoomOptions());
+  const owner = makeClient("owner", "Owner", "necromancer");
+  const peer = makeClient("peer", "Peer", "fighter");
+  room.addClient(owner);
+  room.addClient(peer);
+  room.startRun(Date.now());
+
+  const ownerState = room.activePlayers.get(owner.id);
+  assert.ok(ownerState, "owner active player state missing");
+  ownerState.necromancerRuntime.mimicTimer = 8;
+  ownerState.necromancerRuntime.mimicHealth = 11;
+  room.syncSimPrimaryPlayerState();
+  assert.equal(room.sim.necromancerRuntime.mimicTimer, 8, "test setup failed to seed server mimic runtime");
+
+  room.sim.necromancerRuntime.mimicTimer = 0;
+  room.sim.necromancerRuntime.mimicHealth = 0;
+  room.syncPrimaryActivePlayerFromSim();
+  const syncedOwner = room.activePlayers.get(owner.id);
+  assert.equal(syncedOwner.necromancerRuntime.mimicTimer, 0, "pause-owner active snapshot kept stale mimic timer");
+  assert.equal(syncedOwner.necromancerRuntime.mimicHealth, 0, "pause-owner active snapshot kept stale mimic health");
+
+  const px = room.sim.player.x;
+  const py = room.sim.player.y;
+  room.sim.enemies = [
+    makeStatusEnemy("status-a", px + 40, py),
+    makeStatusEnemy("status-b", px + 70, py + 20),
+    makeStatusEnemy("status-c", px + 100, py - 20),
+    makeStatusEnemy("status-d", px + 130, py)
+  ];
+  room.sim.enemies.push({
+    id: "mimic-dormant",
+    type: "mimic",
+    x: px + 72,
+    y: py + 64,
+    size: 20,
+    hp: 12,
+    maxHp: 12,
+    dormant: true,
+    revealed: false,
+    tongueDirX: -1,
+    tongueDirY: 0,
+    tongueLength: 16
+  });
+  room.auditServerState({ source: "validatorSeed" });
+  const serverStatusAudit = room.recentServerStateAnomalies.find((entry) => entry.kind === "enemyStatusFanout");
+  assert.ok(serverStatusAudit, "server audit did not capture enemy status fanout");
+  assert.equal(serverStatusAudit.tripleStatusCount, 4, "server audit did not include triple status count");
+
+  const peerState = room.activePlayers.get(peer.id);
+  assert.ok(peerState, "peer active player state missing");
+  const pausedPeerX = peerState.x;
+  const pausedPeerY = peerState.y;
+  peer.input = {
+    ...peer.input,
+    seq: 42,
+    moveX: 1,
+    moveY: 0,
+    firePrimaryQueued: true,
+    firePrimaryHeld: true,
+    hasAim: true,
+    aimDirX: 1,
+    aimDirY: 0
+  };
+  room.sim.paused = true;
+  const pausedStatusBefore = room.sim.enemies.map((enemy) => ({
+    id: enemy.id,
+    hpBarTimer: enemy.hpBarTimer,
+    burningTimer: enemy.burningTimer,
+    curseTimer: enemy.curseTimer,
+    rotTimer: enemy.rotTimer,
+    burningDps: enemy.burningDps,
+    rotDps: enemy.rotDps
+  }));
+  const pausedBulletCount = room.sim.bullets.length;
+  const pausedFireArrowCount = room.sim.fireArrows.length;
+  room.tick(Date.now() + 1000, 0);
+  room.tick(Date.now() + 2000, 0);
+  assert.deepEqual(
+    room.sim.enemies.map((enemy) => ({
+      id: enemy.id,
+      hpBarTimer: enemy.hpBarTimer,
+      burningTimer: enemy.burningTimer,
+      curseTimer: enemy.curseTimer,
+      rotTimer: enemy.rotTimer,
+      burningDps: enemy.burningDps,
+      rotDps: enemy.rotDps
+    })),
+    pausedStatusBefore,
+    "paused authoritative tick mutated enemy status presentation state"
+  );
+  assert.equal(peerState.x, pausedPeerX, "paused authoritative tick moved a remote player");
+  assert.equal(peerState.y, pausedPeerY, "paused authoritative tick moved a remote player vertically");
+  assert.equal(room.sim.bullets.length, pausedBulletCount, "paused authoritative tick spawned bullets");
+  assert.equal(room.sim.fireArrows.length, pausedFireArrowCount, "paused authoritative tick spawned fire arrows");
+  room.sim.paused = false;
+
+  const fullState = serializeState(room);
+  const ownerSnapshot = fullState.players.find((player) => player.id === owner.id);
+  assert.equal(ownerSnapshot?.necromancerRuntime?.mimicTimer, 0, "serialized owner snapshot exposed stale mimic timer");
+  const mimicSnapshot = fullState.enemies.find((enemy) => enemy.type === "mimic");
+  assert.equal(mimicSnapshot?.dormant, true, "serialized mimic dropped dormant presentation state");
+  assert.equal(mimicSnapshot?.tongueLength, 16, "serialized mimic dropped tongue presentation state");
+
+  const client = new GameSim({ classType: "fighter", viewportWidth: 960, viewportHeight: 640 });
+  client.networkEnabled = true;
+  client.player.id = peer.id;
+  client.player.x = px;
+  client.player.y = py;
+  applySnapshotToGame({
+    game: client,
+    state: {
+      players: fullState.players,
+      delta: {
+        keyframe: true,
+        enemies: buildDeltaCollection(new Map(), fullState.enemies, true)
+      },
+      serverStateAnomalies: room.recentServerStateAnomalies
+    },
+    controller: false,
+    localPlayerId: peer.id,
+    ackSeq: 12
+  });
+  assert.ok(latestAnomaly(client, "enemyStatusFanout"), "telemetry did not mark enemy status fanout");
+  assert.ok(latestServerAnomaly(client, "enemyStatusFanout"), "client did not preserve server-side status audit");
+  assert.equal(latestAnomaly(client, "playerMimicRuntimeVisible"), null, "clean snapshot still reported player mimic runtime");
+
+  const corruptPlayerState = {
+    players: [
+      {
+        id: owner.id,
+        handle: "Owner",
+        classType: "necromancer",
+        x: px + 32,
+        y: py,
+        size: 22,
+        health: 100,
+        maxHealth: 100,
+        alive: true,
+        necromancerRuntime: { mimicTimer: 6, mimicHealth: 9 }
+      }
+    ],
+    delta: { keyframe: true, enemies: {} }
+  };
+  applySnapshotToGame({ game: client, state: corruptPlayerState, controller: false, localPlayerId: peer.id, ackSeq: 13 });
+  const mimicTelemetry = latestAnomaly(client, "playerMimicRuntimeVisible");
+  assert.ok(mimicTelemetry, "telemetry did not mark player mimic runtime visibility");
+  assert.equal(mimicTelemetry.remoteMimicCount, 1, "player mimic telemetry did not include remote mimic count");
+
+  client.enemies = [makeStatusEnemy("presentation", px, py)];
+  stepNetworkEnemyPresentation(client.enemies, 0.45);
+  assert.equal(client.enemies[0].hpBarTimer, 0.75, "presentation hp bar timer did not age by render delta");
+  stepNetworkEnemyPresentation(client.enemies, 1.5);
+  assert.equal(client.enemies[0].burningTimer, 0, "presentation burning timer did not clear after stall");
+  assert.equal(client.enemies[0].curseTimer, 0, "presentation curse timer did not clear after stall");
+  assert.equal(client.enemies[0].rotTimer, 0, "presentation rot timer did not clear after stall");
+  assert.equal(client.enemies[0].burningDps, 0, "presentation burning dps did not clear with timer");
+  assert.equal(client.enemies[0].rotDps, 0, "presentation rot dps did not clear with timer");
+
+  const negativeRoom = new AuthoritativeRoom("validate-negative-tick-delta", "archer", createRoomOptions());
+  const negativeOwner = makeClient("negative-owner", "NegativeOwner", "archer");
+  negativeRoom.addClient(negativeOwner);
+  negativeRoom.startRun(Date.now());
+  const nx = negativeRoom.sim.player.x + 500;
+  const ny = negativeRoom.sim.player.y + 500;
+  negativeRoom.sim.enemies = [{
+    id: "clean-status",
+    type: "skeleton",
+    x: nx,
+    y: ny,
+    size: 18,
+    hp: 10,
+    maxHp: 10,
+    hpBarTimer: 0,
+    burningTimer: 0,
+    burningDps: 0,
+    curseTimer: 0,
+    rotTimer: 0,
+    rotDps: 0
+  }];
+  if (negativeRoom.sim.necromancerRuntime) {
+    negativeRoom.sim.necromancerRuntime.mimicTimer = 0;
+    negativeRoom.sim.necromancerRuntime.mimicHealth = 0;
+  }
+  const negativeOwnerState = negativeRoom.activePlayers.get(negativeOwner.id);
+  if (negativeOwnerState?.necromancerRuntime) {
+    negativeOwnerState.necromancerRuntime.mimicTimer = 0;
+    negativeOwnerState.necromancerRuntime.mimicHealth = 0;
+  }
+  const negativeNow = Date.now();
+  negativeRoom.lastTickMs = negativeNow + 2915;
+  negativeRoom.tick(negativeNow, 0);
+  const cleanEnemy = negativeRoom.sim.enemies.find((enemy) => enemy.id === "clean-status");
+  assert.ok(cleanEnemy, "negative tick removed clean enemy unexpectedly");
+  assert.equal(cleanEnemy.burningTimer || 0, 0, "negative authoritative dt invented burning timer");
+  assert.equal(cleanEnemy.curseTimer || 0, 0, "negative authoritative dt invented curse timer");
+  assert.equal(cleanEnemy.rotTimer || 0, 0, "negative authoritative dt invented rot timer");
+  assert.equal(cleanEnemy.burningDps || 0, 0, "negative authoritative dt invented burning dps");
+  assert.equal(cleanEnemy.rotDps || 0, 0, "negative authoritative dt invented rot dps");
+  assert.equal(negativeRoom.sim.necromancerRuntime?.mimicTimer || 0, 0, "negative authoritative dt invented primary mimic timer");
+  assert.equal(negativeRoom.activePlayers.get(negativeOwner.id)?.necromancerRuntime?.mimicTimer || 0, 0, "negative authoritative dt invented active player mimic timer");
+  assert.ok(
+    negativeRoom.recentServerStateAnomalies.some((entry) => entry.kind === "negativeTickDelta"),
+    "negative authoritative dt was not recorded for telemetry"
+  );
+
+  console.log(JSON.stringify({
+    networkStateCorruption: "ok",
+    serializedEnemies: fullState.enemies.length,
+    stateAnomalies: client.networkPerf.recentStateAnomalies.map((entry) => entry.kind),
+    serverClockAnomalies: negativeRoom.recentServerStateAnomalies.map((entry) => entry.kind)
+  }, null, 2));
+}
+
+main();

--- a/server/validate-network-vfx-snapshots.js
+++ b/server/validate-network-vfx-snapshots.js
@@ -1,0 +1,136 @@
+import { strict as assert } from "node:assert";
+import { GameSim } from "../src/sim/GameSim.js";
+import { applySnapshotToGame } from "../src/net/clientStateSync.js";
+import { buildDeltaCollection } from "./net/deltaProtocol.js";
+import { serializeState } from "./net/stateSerialization.js";
+
+function createRoom(sim) {
+  return {
+    sim,
+    idMaps: {},
+    idCounters: {},
+    getActivePlayerStates() {
+      return [sim.player];
+    },
+    syncPrimaryActivePlayerFromSim() {
+      return sim.player;
+    }
+  };
+}
+
+function requireEntry(collection, predicate, label) {
+  const entry = (Array.isArray(collection) ? collection : []).find(predicate);
+  assert.ok(entry, `${label} missing`);
+  return entry;
+}
+
+function main() {
+  const sim = new GameSim({ classType: "fighter", viewportWidth: 960, viewportHeight: 640 });
+  sim.player.id = "local-vfx";
+  sim.player.x = 240;
+  sim.player.y = 220;
+  sim.player.classType = "fighter";
+  sim.worldWidth = 960;
+  sim.worldHeight = 640;
+  sim.time = 12.5;
+
+  sim.bullets.push({
+    x: 280,
+    y: 220,
+    vx: 320,
+    vy: 0,
+    angle: 0,
+    life: 0.9,
+    size: 7,
+    damage: 12,
+    projectileType: "mage_fireBolt",
+    damageType: "fire",
+    critMultiplier: 1.5,
+    ownerId: "local-vfx"
+  });
+
+  sim.fireZones.push({
+    x: 260,
+    y: 250,
+    radius: 64,
+    life: 2.5,
+    totalLife: 3,
+    zoneType: "warCircle",
+    damageType: "physical",
+    doctrine: "berserker",
+    ownerId: "local-vfx",
+    followOwner: true,
+    size: 96,
+    strikeAt: 0.75,
+    visualLife: 2.5
+  });
+
+  sim.meleeSwings.push({
+    x: sim.player.x,
+    y: sim.player.y,
+    angle: 0.25,
+    arc: Math.PI * 0.7,
+    range: 64,
+    life: 0.45,
+    maxLife: 0.95,
+    style: "warWhip",
+    modifier: "cleaving",
+    doctrine: "eldritch",
+    executeProc: true,
+    ownerId: "local-vfx"
+  });
+
+  const state = serializeState(createRoom(sim));
+  const bullet = requireEntry(state.bullets, (entry) => entry.projectileType === "mage_fireBolt", "serialized mage projectile");
+  assert.equal(bullet.damageType, "fire", "projectile damageType should survive serialization for renderer palette");
+  assert.equal(bullet.critMultiplier, 1.5, "projectile critMultiplier should survive serialization");
+  assert.equal(bullet.ownerId, "local-vfx", "projectile ownerId should survive serialization");
+
+  const zone = requireEntry(state.fireZones, (entry) => entry.zoneType === "warCircle", "serialized war circle");
+  assert.equal(zone.doctrine, "berserker", "fire-zone doctrine should survive serialization for palette selection");
+  assert.equal(zone.ownerId, "local-vfx", "fire-zone ownerId should survive serialization");
+  assert.equal(zone.followOwner, true, "fire-zone followOwner should survive serialization");
+  assert.equal(zone.size, 96, "fire-zone size should survive serialization");
+  assert.equal(zone.strikeAt, 0.75, "fire-zone strikeAt should survive serialization");
+  assert.equal(zone.visualLife, 2.5, "fire-zone visualLife should survive serialization");
+
+  const swing = requireEntry(state.meleeSwings, (entry) => entry.style === "warWhip", "serialized melee swing");
+  assert.equal(swing.modifier, "cleaving", "melee modifier should survive serialization");
+  assert.equal(swing.doctrine, "eldritch", "melee doctrine should survive serialization");
+  assert.equal(swing.executeProc, true, "melee executeProc should survive serialization");
+  assert.equal(swing.maxLife, 0.95, "melee maxLife should survive serialization");
+  assert.equal(swing.ownerId, "local-vfx", "melee ownerId should survive serialization");
+
+  const deltaCache = new Map();
+  const zoneDelta = buildDeltaCollection(deltaCache, state.fireZones, true);
+  assert.equal(zoneDelta.spawn[0].doctrine, "berserker", "keyframe delta should preserve fire-zone doctrine");
+  assert.equal(zoneDelta.spawn[0].followOwner, true, "keyframe delta should preserve fire-zone followOwner");
+
+  const swingDelta = buildDeltaCollection(new Map(), state.meleeSwings, true);
+  assert.equal(swingDelta.spawn[0].style, "warWhip", "keyframe delta should preserve melee style");
+  assert.equal(swingDelta.spawn[0].executeProc, true, "keyframe delta should preserve melee executeProc");
+
+  const client = new GameSim({ classType: "fighter", viewportWidth: 960, viewportHeight: 640 });
+  client.player.id = "local-vfx";
+  applySnapshotToGame({
+    game: client,
+    state,
+    controller: false,
+    localPlayerId: "local-vfx"
+  });
+
+  assert.equal(client.bullets[0]?.damageType, "fire", "client projectile should keep damageType after snapshot application");
+  assert.equal(client.fireZones[0]?.doctrine, "berserker", "client fire-zone should keep doctrine after snapshot application");
+  assert.equal(client.fireZones[0]?.size, 96, "client fire-zone should keep size after snapshot application");
+  assert.equal(client.meleeSwings[0]?.style, "warWhip", "client melee swing should keep style after snapshot application");
+  assert.equal(client.meleeSwings[0]?.executeProc, true, "client melee swing should keep executeProc after snapshot application");
+
+  console.log(JSON.stringify({
+    networkVfxSnapshots: "ok",
+    bullets: state.bullets.length,
+    fireZones: state.fireZones.length,
+    meleeSwings: state.meleeSwings.length
+  }, null, 2));
+}
+
+main();

--- a/server/validate-network-vfx-snapshots.js
+++ b/server/validate-network-vfx-snapshots.js
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { GameSim } from "../src/sim/GameSim.js";
 import { applySnapshotToGame } from "../src/net/clientStateSync.js";
+import { rendererEffectsProjectileMethods } from "../src/rendering/rendererEffectsProjectileMethods.js";
 import { buildDeltaCollection } from "./net/deltaProtocol.js";
 import { serializeState } from "./net/stateSerialization.js";
 
@@ -22,6 +23,25 @@ function requireEntry(collection, predicate, label) {
   const entry = (Array.isArray(collection) ? collection : []).find(predicate);
   assert.ok(entry, `${label} missing`);
   return entry;
+}
+
+function createCaptureContext() {
+  const calls = [];
+  const gradient = { addColorStop() {} };
+  return {
+    calls,
+    save() { calls.push(["save"]); },
+    restore() { calls.push(["restore"]); },
+    beginPath() { calls.push(["beginPath"]); },
+    closePath() { calls.push(["closePath"]); },
+    moveTo(...args) { calls.push(["moveTo", ...args]); },
+    lineTo(...args) { calls.push(["lineTo", ...args]); },
+    arc(...args) { calls.push(["arc", ...args]); },
+    fill() { calls.push(["fill"]); },
+    stroke() { calls.push(["stroke"]); },
+    createRadialGradient() { return gradient; },
+    createLinearGradient() { return gradient; }
+  };
 }
 
 function main() {
@@ -79,8 +99,26 @@ function main() {
     executeProc: true,
     ownerId: "local-vfx"
   });
+  sim.enemies.push({
+    id: "mimic-vfx",
+    type: "mimic",
+    x: 300,
+    y: 260,
+    size: 20,
+    hp: 10,
+    maxHp: 10,
+    dormant: true,
+    revealed: false,
+    tongueDirX: -1,
+    tongueDirY: 0,
+    tongueLength: 12
+  });
 
   const state = serializeState(createRoom(sim));
+  const mimic = requireEntry(state.enemies, (entry) => entry.type === "mimic", "serialized mimic");
+  assert.equal(mimic.dormant, true, "mimic dormant state should survive serialization");
+  assert.equal(mimic.tongueDirX, -1, "mimic tongue direction should survive serialization");
+  assert.equal(mimic.tongueLength, 12, "mimic tongue length should survive serialization");
   const bullet = requireEntry(state.bullets, (entry) => entry.projectileType === "mage_fireBolt", "serialized mage projectile");
   assert.equal(bullet.damageType, "fire", "projectile damageType should survive serialization for renderer palette");
   assert.equal(bullet.critMultiplier, 1.5, "projectile critMultiplier should survive serialization");
@@ -110,8 +148,51 @@ function main() {
   assert.equal(swingDelta.spawn[0].style, "warWhip", "keyframe delta should preserve melee style");
   assert.equal(swingDelta.spawn[0].executeProc, true, "keyframe delta should preserve melee executeProc");
 
+  const enemyDeltaCache = new Map();
+  const enemyWithStatuses = {
+    id: "e_status",
+    type: "ghost",
+    x: 120,
+    y: 140,
+    size: 20,
+    hp: 6,
+    maxHp: 6,
+    burningTimer: 1.2,
+    burningDps: 3,
+    curseTimer: 2.5,
+    rotTimer: 4,
+    rotDps: 2
+  };
+  buildDeltaCollection(enemyDeltaCache, [enemyWithStatuses], true);
+  const statusClearDelta = buildDeltaCollection(enemyDeltaCache, [{
+    id: "e_status",
+    type: "ghost",
+    x: 122,
+    y: 140,
+    size: 20,
+    hp: 6,
+    maxHp: 6
+  }], false);
+  const clearPatch = statusClearDelta.update.find((entry) => entry.id === "e_status");
+  assert.equal(clearPatch.burningTimer, null, "enemy delta should explicitly clear expired burningTimer");
+  assert.equal(clearPatch.burningDps, null, "enemy delta should explicitly clear expired burningDps");
+  assert.equal(clearPatch.curseTimer, null, "enemy delta should explicitly clear expired curseTimer");
+  assert.equal(clearPatch.rotTimer, null, "enemy delta should explicitly clear expired rotTimer");
+  assert.equal(clearPatch.rotDps, null, "enemy delta should explicitly clear expired rotDps");
+
   const client = new GameSim({ classType: "fighter", viewportWidth: 960, viewportHeight: 640 });
   client.player.id = "local-vfx";
+  client.enemies = [{ ...enemyWithStatuses }];
+  applySnapshotToGame({
+    game: client,
+    state: { delta: { keyframe: false, enemies: statusClearDelta } },
+    controller: false,
+    localPlayerId: "local-vfx"
+  });
+  assert.equal(client.enemies[0]?.burningTimer, null, "client enemy should clear expired burningTimer from delta");
+  assert.equal(client.enemies[0]?.curseTimer, null, "client enemy should clear expired curseTimer from delta");
+  assert.equal(client.enemies[0]?.rotTimer, null, "client enemy should clear expired rotTimer from delta");
+
   applySnapshotToGame({
     game: client,
     state,
@@ -124,6 +205,40 @@ function main() {
   assert.equal(client.fireZones[0]?.size, 96, "client fire-zone should keep size after snapshot application");
   assert.equal(client.meleeSwings[0]?.style, "warWhip", "client melee swing should keep style after snapshot application");
   assert.equal(client.meleeSwings[0]?.executeProc, true, "client melee swing should keep executeProc after snapshot application");
+
+  const captureCtx = createCaptureContext();
+  const renderer = {
+    ctx: captureCtx,
+    config: { effects: { meleeSwingLife: 0.17 } },
+    drawMeleeSwing: rendererEffectsProjectileMethods.drawMeleeSwing
+  };
+  rendererEffectsProjectileMethods.drawProjectiles.call(renderer, {
+    player: { x: 900, y: 500 },
+    bullets: [],
+    fireArrows: [],
+    fireZones: [],
+    necromancerRuntime: { souls: [] },
+    time: 0,
+    meleeSwings: [{
+      x: 240,
+      y: 220,
+      angle: 0,
+      arc: Math.PI * 0.7,
+      range: 64,
+      life: 0.17,
+      maxLife: 0.17,
+      style: "broadswing"
+    }]
+  }, 0, 0);
+  assert.ok(
+    captureCtx.calls.some((call) => call[0] === "moveTo" && call[1] === 252 && call[2] === 220),
+    "melee swing handle should be anchored to swing origin, not local player"
+  );
+  assert.equal(
+    captureCtx.calls.some((call) => call[0] === "moveTo" && call[1] === 912 && call[2] === 500),
+    false,
+    "remote melee swing handle incorrectly anchored to local player"
+  );
 
   console.log(JSON.stringify({
     networkVfxSnapshots: "ok",

--- a/server/validate-player-state-sync.js
+++ b/server/validate-player-state-sync.js
@@ -1,0 +1,142 @@
+import { strict as assert } from "node:assert";
+import { AuthoritativeRoom } from "./net/AuthoritativeRoom.js";
+import { buildDeltaCollection } from "./net/deltaProtocol.js";
+import { buildMapChunkRows } from "./net/mapChunkStreaming.js";
+import { getStableId, serializeMetaState, serializeState } from "./net/stateSerialization.js";
+import { average, monotonicNowMs, percentile } from "./net/telemetry.js";
+import { makeDefaultInput } from "./net/serverHelpers.js";
+import { chooseGameplayTrack } from "./musicCatalog.js";
+import { GameSim } from "../src/sim/GameSim.js";
+import { syncNamedObject } from "../src/net/clientSnapshotHelpers.js";
+import { applyPlayerSnapshotToGameState, ACTIVE_PLAYER_SNAPSHOT_FIELDS } from "../src/net/playerSnapshotSchema.js";
+
+function createFakeSocket() {
+  return {
+    OPEN: 1,
+    readyState: 1,
+    bufferedAmount: 0,
+    send() {}
+  };
+}
+
+function makeClient(id, name, classType) {
+  return {
+    id,
+    name,
+    classType,
+    protocolVersion: 2,
+    ws: createFakeSocket(),
+    input: makeDefaultInput(),
+    lastInputSeq: 0,
+    classLocked: true
+  };
+}
+
+function createRoomOptions() {
+  return {
+    average,
+    buildDeltaCollection,
+    buildMapChunkRows,
+    chooseGameplayTrack,
+    deltaKeyframeEvery: 30,
+    getStableId,
+    makeDefaultInput,
+    mapChunkPushMs: 120,
+    mapChunkRadius: 2,
+    mapChunkSize: 24,
+    maxWsBufferedBytes: 262144,
+    metaBroadcastMinMs: 320,
+    monotonicNowMs,
+    percentile,
+    pushTelemetrySample() {},
+    serializeMetaState,
+    serializeState,
+    snapshotAckGapForceKeyframe: 8,
+    tickDriftEpsilonMs: 0.5
+  };
+}
+
+function assertSnapshotFields(snapshot) {
+  for (const field of ACTIVE_PLAYER_SNAPSHOT_FIELDS) {
+    assert.ok(Object.prototype.hasOwnProperty.call(snapshot, field), `active player snapshot missing ${field}`);
+  }
+}
+
+function main() {
+  const room = new AuthoritativeRoom("validate-player-state-sync", "archer", createRoomOptions());
+  const owner = makeClient("owner", "Owner", "necromancer");
+  const peer = makeClient("peer", "Peer", "fighter");
+  room.addClient(owner);
+  room.addClient(peer);
+  room.startRun(Date.now());
+
+  const ownerState = room.activePlayers.get(owner.id);
+  assert.ok(ownerState, "owner active player state missing");
+  ownerState.level = 4;
+  ownerState.score = 321;
+  ownerState.gold = 123;
+  ownerState.experience = 17;
+  ownerState.skillPoints = 2;
+  ownerState.refundCount = 1;
+  ownerState.levelWeaponDamageBonus = 9;
+  ownerState.fireCooldown = 0.25;
+  ownerState.fireArrowCooldown = 0.5;
+  ownerState.deathBoltCooldown = 0.75;
+  ownerState.lanternFuel = 0.42;
+  ownerState.necromancerRuntime.activeMode = "spell";
+  ownerState.necromancerRuntime.mana = 3;
+  ownerState.necromancerTalents.fireBoltCantrip.points = 1;
+  ownerState.skills.deathBolt.points = 3;
+  ownerState.consumables.sharedCooldown = 1.2;
+  ownerState.necromancerBeam.active = true;
+  ownerState.necromancerBeam.targetX = 77;
+  ownerState.necromancerBeam.targetY = 88;
+
+  room.syncSimPrimaryPlayerState();
+  assert.equal(room.sim.classType, "necromancer", "primary sim class did not sync from active state");
+  assert.equal(room.sim.level, 4, "primary sim level did not sync from active state");
+  assert.equal(room.sim.gold, 123, "primary sim gold did not sync from active state");
+  assert.equal(room.sim.skills.deathBolt.points, 3, "primary sim skills did not sync from active state");
+  assert.equal(room.sim.necromancerTalents.fireBoltCantrip.points, 1, "primary sim talents did not sync from active state");
+
+  room.sim.gold = 456;
+  room.sim.level = 5;
+  room.sim.player.health = 44;
+  room.sim.player.fireCooldown = 0.125;
+  room.sim.skills.deathBolt.points = 4;
+  room.sim.necromancerRuntime.activeMode = "cantrip";
+  room.sim.necromancerBeam.progress = 0.6;
+  const syncedOwner = room.syncPrimaryActivePlayerFromSim();
+  assert.equal(syncedOwner.gold, 456, "active state gold did not sync from primary sim");
+  assert.equal(syncedOwner.level, 5, "active state level did not sync from primary sim");
+  assert.equal(syncedOwner.health, 44, "active state health did not sync from primary sim");
+  assert.equal(syncedOwner.fireCooldown, 0.125, "active state cooldown did not sync from primary sim");
+  assert.equal(syncedOwner.skills.deathBolt.points, 4, "active state skills did not sync from primary sim");
+  assert.equal(syncedOwner.necromancerBeam.progress, 0.6, "active state beam did not sync from primary sim");
+
+  const state = serializeState(room);
+  const ownerSnapshot = state.players.find((player) => player.id === owner.id);
+  assert.ok(ownerSnapshot, "serialized owner snapshot missing from players collection");
+  assertSnapshotFields(ownerSnapshot);
+  assert.equal(ownerSnapshot.gold, 456, "serialized owner snapshot did not include active gold");
+  assert.equal(ownerSnapshot.fireCooldown, 0.125, "serialized owner snapshot did not include cooldown");
+  assert.equal(ownerSnapshot.necromancerBeam.progress, 0.6, "serialized owner snapshot did not include beam state");
+
+  const clientGame = new GameSim({ classType: "archer", viewportWidth: 960, viewportHeight: 640 });
+  applyPlayerSnapshotToGameState(clientGame, ownerSnapshot, { isNetworkController: false, syncNamedObject });
+  assert.equal(clientGame.classType, "necromancer", "client class did not apply from player snapshot");
+  assert.equal(clientGame.gold, 456, "client gold did not apply from player snapshot");
+  assert.equal(clientGame.player.health, 44, "client health did not apply from player snapshot");
+  assert.equal(clientGame.player.fireCooldown, 0.125, "client cooldown did not apply from player snapshot");
+  assert.equal(clientGame.skills.deathBolt.points, 4, "client skills did not apply from player snapshot");
+  assert.equal(clientGame.necromancerBeam.progress, 0.6, "client beam did not apply from player snapshot");
+
+  console.log(JSON.stringify({
+    playerStateSync: "ok",
+    snapshotFields: ACTIVE_PLAYER_SNAPSHOT_FIELDS.length,
+    ownerClass: clientGame.classType,
+    ownerGold: clientGame.gold
+  }, null, 2));
+}
+
+main();

--- a/server/validate-player-state-sync.js
+++ b/server/validate-player-state-sync.js
@@ -98,6 +98,8 @@ function main() {
   assert.equal(room.sim.gold, 123, "primary sim gold did not sync from active state");
   assert.equal(room.sim.skills.deathBolt.points, 3, "primary sim skills did not sync from active state");
   assert.equal(room.sim.necromancerTalents.fireBoltCantrip.points, 1, "primary sim talents did not sync from active state");
+  assert.equal(room.sim.necromancerRuntime.activeMode, "spell", "primary sim necromancer runtime did not sync from active state");
+  assert.equal(room.sim.necromancerRuntime.mana, 3, "primary sim necromancer mana did not sync from active state");
 
   room.sim.gold = 456;
   room.sim.level = 5;
@@ -105,6 +107,8 @@ function main() {
   room.sim.player.fireCooldown = 0.125;
   room.sim.skills.deathBolt.points = 4;
   room.sim.necromancerRuntime.activeMode = "cantrip";
+  room.sim.necromancerRuntime.mimicTimer = 0;
+  room.sim.necromancerRuntime.mimicHealth = 0;
   room.sim.necromancerBeam.progress = 0.6;
   const syncedOwner = room.syncPrimaryActivePlayerFromSim();
   assert.equal(syncedOwner.gold, 456, "active state gold did not sync from primary sim");
@@ -112,6 +116,8 @@ function main() {
   assert.equal(syncedOwner.health, 44, "active state health did not sync from primary sim");
   assert.equal(syncedOwner.fireCooldown, 0.125, "active state cooldown did not sync from primary sim");
   assert.equal(syncedOwner.skills.deathBolt.points, 4, "active state skills did not sync from primary sim");
+  assert.equal(syncedOwner.necromancerRuntime.activeMode, "cantrip", "active state necromancer runtime mode did not sync from primary sim");
+  assert.equal(syncedOwner.necromancerRuntime.mimicTimer, 0, "active state necromancer mimic timer stayed stale after primary sim sync");
   assert.equal(syncedOwner.necromancerBeam.progress, 0.6, "active state beam did not sync from primary sim");
 
   const state = serializeState(room);
@@ -120,6 +126,7 @@ function main() {
   assertSnapshotFields(ownerSnapshot);
   assert.equal(ownerSnapshot.gold, 456, "serialized owner snapshot did not include active gold");
   assert.equal(ownerSnapshot.fireCooldown, 0.125, "serialized owner snapshot did not include cooldown");
+  assert.equal(ownerSnapshot.necromancerRuntime.mimicTimer, 0, "serialized owner snapshot kept stale mimic timer");
   assert.equal(ownerSnapshot.necromancerBeam.progress, 0.6, "serialized owner snapshot did not include beam state");
 
   const clientGame = new GameSim({ classType: "archer", viewportWidth: 960, viewportHeight: 640 });
@@ -129,6 +136,7 @@ function main() {
   assert.equal(clientGame.player.health, 44, "client health did not apply from player snapshot");
   assert.equal(clientGame.player.fireCooldown, 0.125, "client cooldown did not apply from player snapshot");
   assert.equal(clientGame.skills.deathBolt.points, 4, "client skills did not apply from player snapshot");
+  assert.equal(clientGame.necromancerRuntime.mimicTimer, 0, "client mimic timer did not clear from player snapshot");
   assert.equal(clientGame.necromancerBeam.progress, 0.6, "client beam did not apply from player snapshot");
 
   console.log(JSON.stringify({

--- a/src/bootstrap/debugRuntime.js
+++ b/src/bootstrap/debugRuntime.js
@@ -29,6 +29,12 @@ export function installDebugRuntime({ getCurrentGame, getMusicDebugState, getNet
               y: enemy.y,
               hp: enemy.hp,
               maxHp: enemy.maxHp,
+              hpBarTimer: Number.isFinite(enemy.hpBarTimer) ? enemy.hpBarTimer : 0,
+              burningTimer: Number.isFinite(enemy.burningTimer) ? enemy.burningTimer : 0,
+              curseTimer: Number.isFinite(enemy.curseTimer) ? enemy.curseTimer : 0,
+              rotTimer: Number.isFinite(enemy.rotTimer) ? enemy.rotTimer : 0,
+              burningDps: Number.isFinite(enemy.burningDps) ? enemy.burningDps : 0,
+              rotDps: Number.isFinite(enemy.rotDps) ? enemy.rotDps : 0,
               size: enemy.size || 0,
               distToPlayer: Math.hypot((enemy.x || 0) - playerX, (enemy.y || 0) - playerY),
               screenX: (enemy.x || 0) - camera.x,
@@ -295,6 +301,14 @@ export function installDebugRuntime({ getCurrentGame, getMusicDebugState, getNet
               projectileReconcileRejects: game.networkPerf.projectileReconcileRejects || 0,
               recentProjectileReconcileRejects: Array.isArray(game.networkPerf.recentProjectileReconcileRejects)
                 ? game.networkPerf.recentProjectileReconcileRejects.slice(-8).map((entry) => ({ ...entry }))
+                : [],
+              networkStateAnomalyEventId: game.networkPerf.networkStateAnomalyEventId || 0,
+              recentStateAnomalies: Array.isArray(game.networkPerf.recentStateAnomalies)
+                ? game.networkPerf.recentStateAnomalies.slice(-12).map((entry) => ({ ...entry }))
+                : [],
+              serverStateAnomalyEventId: game.networkPerf.serverStateAnomalyEventId || 0,
+              recentServerStateAnomalies: Array.isArray(game.networkPerf.recentServerStateAnomalies)
+                ? game.networkPerf.recentServerStateAnomalies.slice(-12).map((entry) => ({ ...entry }))
                 : []
             }
           : null,

--- a/src/bootstrap/debugRuntime.js
+++ b/src/bootstrap/debugRuntime.js
@@ -288,6 +288,10 @@ export function installDebugRuntime({ getCurrentGame, getMusicDebugState, getNet
               recentPostLoadCorrections: Array.isArray(game.networkPerf.recentPostLoadCorrections)
                 ? game.networkPerf.recentPostLoadCorrections.slice(-8).map((entry) => ({ ...entry }))
                 : [],
+              networkFlightEventId: game.networkPerf.networkFlightEventId || 0,
+              recentFlightEvents: Array.isArray(game.networkPerf.recentFlightEvents)
+                ? game.networkPerf.recentFlightEvents.slice(-24).map((entry) => ({ ...entry }))
+                : [],
               projectileReconcileRejects: game.networkPerf.projectileReconcileRejects || 0,
               recentProjectileReconcileRejects: Array.isArray(game.networkPerf.recentProjectileReconcileRejects)
                 ? game.networkPerf.recentProjectileReconcileRejects.slice(-8).map((entry) => ({ ...entry }))
@@ -379,6 +383,16 @@ export function installDebugRuntime({ getCurrentGame, getMusicDebugState, getNet
         torch.lit = data?.lit !== false;
         if (torch.lit) torch.snuffCooldown = 0;
         return { ok: true, id: torch.id || null, lit: torch.lit };
+      }
+      if (command === "dumpNetworkFlightRecorder") {
+        const perf = game.networkPerf && typeof game.networkPerf === "object" ? game.networkPerf : {};
+        return {
+          ok: true,
+          eventId: Number.isFinite(perf.networkFlightEventId) ? perf.networkFlightEventId : 0,
+          events: Array.isArray(perf.recentFlightEvents) ? perf.recentFlightEvents.map((entry) => ({ ...entry })) : [],
+          corrections: Array.isArray(perf.recentCorrections) ? perf.recentCorrections.map((entry) => ({ ...entry })) : [],
+          postLoadCorrections: Array.isArray(perf.recentPostLoadCorrections) ? perf.recentPostLoadCorrections.map((entry) => ({ ...entry })) : []
+        };
       }
       return { ok: false, error: "unknownCommand" };
     }

--- a/src/bootstrap/devNetworkTelemetryRecorder.js
+++ b/src/bootstrap/devNetworkTelemetryRecorder.js
@@ -227,6 +227,36 @@ function buildSample(state, startedAtMs, previousPerf = {}) {
         afterY: numberOrNull(entry.afterY)
       }))
     : [];
+  const recentStateAnomalies = Array.isArray(perf.recentStateAnomalies)
+    ? perf.recentStateAnomalies.slice(-8).map((entry) => ({
+        id: numberOrNull(entry.id),
+        atMs: numberOrNull(entry.atMs),
+        kind: typeof entry.kind === "string" ? entry.kind : "",
+        keyframe: booleanOrNull(entry.keyframe),
+        ackSeq: numberOrNull(entry.ackSeq),
+        enemyCount: numberOrNull(entry.enemyCount),
+        tripleStatusCount: numberOrNull(entry.tripleStatusCount),
+        fullHpBarCount: numberOrNull(entry.fullHpBarCount),
+        localMimicTimer: numberOrNull(entry.localMimicTimer),
+        remoteMimicCount: numberOrNull(entry.remoteMimicCount),
+        remotePlayerIds: Array.isArray(entry.remotePlayerIds) ? entry.remotePlayerIds.slice(0, 6) : []
+      }))
+    : [];
+  const recentServerStateAnomalies = Array.isArray(perf.recentServerStateAnomalies)
+    ? perf.recentServerStateAnomalies.slice(-8).map((entry) => ({
+        id: numberOrNull(entry.id),
+        atMs: numberOrNull(entry.atMs),
+        snapshotSeq: numberOrNull(entry.snapshotSeq),
+        kind: typeof entry.kind === "string" ? entry.kind : "",
+        paused: booleanOrNull(entry.paused),
+        context: entry.context && typeof entry.context === "object" ? { ...entry.context } : null,
+        enemyCount: numberOrNull(entry.enemyCount),
+        tripleStatusCount: numberOrNull(entry.tripleStatusCount),
+        tripleStatusEnemies: Array.isArray(entry.tripleStatusEnemies) ? entry.tripleStatusEnemies.slice(0, 4) : [],
+        mimicPlayers: Array.isArray(entry.mimicPlayers) ? entry.mimicPlayers.slice(0, 4) : [],
+        classMismatches: Array.isArray(entry.classMismatches) ? entry.classMismatches.slice(0, 4) : []
+      }))
+    : [];
   return {
     kind: "sample",
     at: new Date().toISOString(),
@@ -275,6 +305,10 @@ function buildSample(state, startedAtMs, previousPerf = {}) {
     recentPostLoadCorrections,
     networkFlightEventId: numberOrNull(perf.networkFlightEventId),
     recentFlightEvents,
+    networkStateAnomalyEventId: numberOrNull(perf.networkStateAnomalyEventId),
+    recentStateAnomalies,
+    serverStateAnomalyEventId: numberOrNull(perf.serverStateAnomalyEventId),
+    recentServerStateAnomalies,
     hardSnapCount: numberOrNull(perf.hardSnapCount),
     softCorrectionCount: numberOrNull(perf.softCorrectionCount),
     settleCorrectionCount: numberOrNull(perf.settleCorrectionCount),

--- a/src/bootstrap/devNetworkTelemetryRecorder.js
+++ b/src/bootstrap/devNetworkTelemetryRecorder.js
@@ -201,6 +201,32 @@ function buildSample(state, startedAtMs, previousPerf = {}) {
         correctedY: numberOrNull(entry.correctedY)
       }))
     : [];
+  const recentFlightEvents = Array.isArray(perf.recentFlightEvents)
+    ? perf.recentFlightEvents.slice(-8).map((entry) => ({
+        id: numberOrNull(entry.id),
+        atMs: numberOrNull(entry.atMs),
+        kind: typeof entry.kind === "string" ? entry.kind : "",
+        snapshotCount: numberOrNull(entry.snapshotCount),
+        controller: booleanOrNull(entry.controller),
+        localController: booleanOrNull(entry.localController),
+        initialSync: booleanOrNull(entry.initialSync),
+        postLoadActive: booleanOrNull(entry.postLoadActive),
+        keyframe: booleanOrNull(entry.keyframe),
+        ackSeq: numberOrNull(entry.ackSeq),
+        pendingInputs: numberOrNull(entry.pendingInputs),
+        jitterMs: numberOrNull(entry.jitterMs),
+        frameGapMs: numberOrNull(entry.frameGapMs),
+        correctionKind: typeof entry.correctionKind === "string" ? entry.correctionKind : "",
+        correctionPx: numberOrNull(entry.correctionPx),
+        appliedPx: numberOrNull(entry.appliedPx),
+        beforeX: numberOrNull(entry.beforeX),
+        beforeY: numberOrNull(entry.beforeY),
+        serverX: numberOrNull(entry.serverX),
+        serverY: numberOrNull(entry.serverY),
+        afterX: numberOrNull(entry.afterX),
+        afterY: numberOrNull(entry.afterY)
+      }))
+    : [];
   return {
     kind: "sample",
     at: new Date().toISOString(),
@@ -247,6 +273,8 @@ function buildSample(state, startedAtMs, previousPerf = {}) {
     postLoadSettleCorrectionCount: numberOrNull(perf.postLoadSettleCorrectionCount),
     postLoadBlockedSnapCount: numberOrNull(perf.postLoadBlockedSnapCount),
     recentPostLoadCorrections,
+    networkFlightEventId: numberOrNull(perf.networkFlightEventId),
+    recentFlightEvents,
     hardSnapCount: numberOrNull(perf.hardSnapCount),
     softCorrectionCount: numberOrNull(perf.softCorrectionCount),
     settleCorrectionCount: numberOrNull(perf.settleCorrectionCount),

--- a/src/bootstrap/networkRenderRuntime.js
+++ b/src/bootstrap/networkRenderRuntime.js
@@ -1,5 +1,18 @@
 import { updateDebugHudFrameStats, updateDebugHudNetworkStats } from "./debugHudStats.js";
 
+export function stepNetworkEnemyPresentation(enemies, dt) {
+  if (!Array.isArray(enemies) || !Number.isFinite(dt) || dt <= 0) return;
+  for (const enemy of enemies) {
+    if (!enemy) continue;
+    enemy.hpBarTimer = Math.max(0, (Number.isFinite(enemy.hpBarTimer) ? enemy.hpBarTimer : 0) - dt);
+    enemy.burningTimer = Math.max(0, (Number.isFinite(enemy.burningTimer) ? enemy.burningTimer : 0) - dt);
+    enemy.curseTimer = Math.max(0, (Number.isFinite(enemy.curseTimer) ? enemy.curseTimer : 0) - dt);
+    enemy.rotTimer = Math.max(0, (Number.isFinite(enemy.rotTimer) ? enemy.rotTimer : 0) - dt);
+    if (enemy.burningTimer <= 0) enemy.burningDps = 0;
+    if (enemy.rotTimer <= 0) enemy.rotDps = 0;
+  }
+}
+
 export function applyNetworkSnapshot({
   game,
   state,
@@ -42,6 +55,7 @@ export function startNetworkRenderLoopRuntime({
   isNetworkController,
   getRenderDelayMs,
   estimateServerNowMs,
+  getAckSeqForPacket,
   consumeSnapshotForRender,
   netSnapshotBuffer,
   maxSnapshotBuffer,
@@ -98,7 +112,10 @@ export function startNetworkRenderLoopRuntime({
         pkt?.state && typeof pkt.state === "object" && Number.isFinite(pkt.serverTime)
           ? { ...pkt.state, serverTime: pkt.serverTime }
           : pkt.state;
-      applySnapshot(game, stateWithServerTime, isNetworkController(), Number.isFinite(pkt.lastInputSeq) ? pkt.lastInputSeq : 0);
+      const ackSeq = typeof getAckSeqForPacket === "function"
+        ? getAckSeqForPacket(pkt)
+        : Number.isFinite(pkt.lastInputSeq) ? pkt.lastInputSeq : 0;
+      applySnapshot(game, stateWithServerTime, isNetworkController(), ackSeq);
     }
     if (isNetworkController()) {
       const input = collectInput(game, false);
@@ -139,6 +156,7 @@ export function startNetworkRenderLoopRuntime({
       }
     }
     game.floatingTexts = stepClientFloatingTexts(game.floatingTexts, dt);
+    if (!game.paused) stepNetworkEnemyPresentation(game.enemies, dt);
     if (typeof updatePredictedProjectiles === "function") updatePredictedProjectiles(game, netPredictedProjectiles, dt);
     if (typeof updateNetworkProjectilePresentation === "function") updateNetworkProjectilePresentation(game, dt);
     prunePredictedProjectiles(netPredictedProjectiles, performance.now(), predictedProjectileTtlMs, game, predictedProjectileRenderTtlMs);

--- a/src/bootstrap/networkSessionRuntime.js
+++ b/src/bootstrap/networkSessionRuntime.js
@@ -87,6 +87,8 @@ export function createNetworkSessionController({
     gapMs: netLastSnapshotGapMs
   });
 
+  const getAckSeqForPacket = (pkt) => Number.isFinite(pkt?.lastInputSeqByPlayer?.[netPlayerId]) ? pkt.lastInputSeqByPlayer[netPlayerId] : Number.isFinite(pkt?.lastInputSeq) ? pkt.lastInputSeq : 0;
+
   const resetNetworkState = () => {
     netPlayerId = null;
     netVoiceUid = null;
@@ -166,6 +168,7 @@ export function createNetworkSessionController({
       isNetworkController,
       getRenderDelayMs: () => getRenderDelayForRole(isNetworkController, controllerRenderDelayMs, spectatorRenderDelayMs),
       estimateServerNowMs: () => estimateServerNowMsFromState(netClockState),
+      getAckSeqForPacket,
       consumeSnapshotForRender,
       netSnapshotBuffer,
       maxSnapshotBuffer: NET_MAX_SNAPSHOT_BUFFER,
@@ -230,7 +233,7 @@ export function createNetworkSessionController({
           game,
           initialPending.state,
           isNetworkController(),
-          Number.isFinite(initialPending.lastInputSeq) ? initialPending.lastInputSeq : 0
+          getAckSeqForPacket(initialPending)
         );
         netPendingSnapshot = null;
       }
@@ -387,7 +390,7 @@ export function createNetworkSessionController({
         return;
       }
       if (game.networkHasMap && game.networkHasChunks && !game.networkReady && netSnapshotBuffer.length === 0) {
-        applySnapshot(game, msg.state, isNetworkController(), Number.isFinite(msg.lastInputSeq) ? msg.lastInputSeq : 0);
+        applySnapshot(game, msg.state, isNetworkController(), getAckSeqForPacket(msg));
         if (netInitialSnapshotApplied) {
           updateNetworkRole(game, isNetworkController(), networkTakeControl);
           updateNetworkStatusRuntime(networkStatus, getCurrentGame(), `Room synced | Role: ${game.networkRole}`);

--- a/src/net/clientCorrectionMetrics.js
+++ b/src/net/clientCorrectionMetrics.js
@@ -22,7 +22,9 @@ export function ensureNetworkPerf(game) {
     postLoadSettleCorrectionCount: 0,
     postLoadBlockedSnapCount: 0,
     recentPostLoadCorrections: [],
-    recentCorrections: []
+    recentCorrections: [],
+    networkFlightEventId: 0,
+    recentFlightEvents: []
   };
   return game.networkPerf;
 }
@@ -71,6 +73,21 @@ export function recordCorrection(game, kind, errorDist, { ackSeq, pendingInputs,
     ...extra
   });
   trimRecent(perf.recentCorrections);
+}
+
+export function recordNetworkFlightEvent(game, kind, details = {}) {
+  const perf = ensureNetworkPerf(game);
+  if (!Array.isArray(perf.recentFlightEvents)) perf.recentFlightEvents = [];
+  perf.networkFlightEventId = Math.max(0, Number.isFinite(perf.networkFlightEventId) ? Math.floor(perf.networkFlightEventId) : 0) + 1;
+  const event = {
+    id: perf.networkFlightEventId,
+    atMs: nowMs(),
+    kind,
+    ...details
+  };
+  perf.recentFlightEvents.push(event);
+  trimRecent(perf.recentFlightEvents, 96);
+  return event;
 }
 
 export function recordPostLoadCorrection(game, active, kind, errorPx, { ackSeq, pendingDepth, extra = {} } = {}) {

--- a/src/net/clientCorrectionMetrics.js
+++ b/src/net/clientCorrectionMetrics.js
@@ -24,7 +24,11 @@ export function ensureNetworkPerf(game) {
     recentPostLoadCorrections: [],
     recentCorrections: [],
     networkFlightEventId: 0,
-    recentFlightEvents: []
+    recentFlightEvents: [],
+    networkStateAnomalyEventId: 0,
+    recentStateAnomalies: [],
+    serverStateAnomalyEventId: 0,
+    recentServerStateAnomalies: []
   };
   return game.networkPerf;
 }
@@ -88,6 +92,76 @@ export function recordNetworkFlightEvent(game, kind, details = {}) {
   perf.recentFlightEvents.push(event);
   trimRecent(perf.recentFlightEvents, 96);
   return event;
+}
+
+export function recordNetworkStateAnomaly(game, kind, details = {}) {
+  const perf = ensureNetworkPerf(game);
+  if (!Array.isArray(perf.recentStateAnomalies)) perf.recentStateAnomalies = [];
+  perf.networkStateAnomalyEventId = Math.max(
+    0,
+    Number.isFinite(perf.networkStateAnomalyEventId) ? Math.floor(perf.networkStateAnomalyEventId) : 0
+  ) + 1;
+  const event = {
+    id: perf.networkStateAnomalyEventId,
+    atMs: nowMs(),
+    kind,
+    ...details
+  };
+  perf.recentStateAnomalies.push(event);
+  trimRecent(perf.recentStateAnomalies, 48);
+  return event;
+}
+
+export function recordSuspiciousNetworkState(game, { keyframe = false, ackSeq = 0 } = {}) {
+  if (!game?.networkPerf) return;
+  const enemies = Array.isArray(game.enemies) ? game.enemies : [];
+  let tripleStatusCount = 0;
+  let fullHpBarCount = 0;
+  for (const enemy of enemies) {
+    if (!enemy) continue;
+    if ((enemy.burningTimer || 0) > 0 && (enemy.curseTimer || 0) > 0 && (enemy.rotTimer || 0) > 0) {
+      tripleStatusCount += 1;
+    }
+    if ((enemy.hpBarTimer || 0) >= 0.85 && Number.isFinite(enemy.hp) && Number.isFinite(enemy.maxHp) && enemy.hp >= enemy.maxHp) {
+      fullHpBarCount += 1;
+    }
+  }
+  const enemyCount = enemies.length;
+  if (enemyCount >= 3 && tripleStatusCount >= Math.max(3, Math.ceil(enemyCount * 0.5))) {
+    recordNetworkStateAnomaly(game, "enemyStatusFanout", {
+      keyframe: !!keyframe,
+      ackSeq: Number.isFinite(ackSeq) ? ackSeq : 0,
+      enemyCount,
+      tripleStatusCount,
+      fullHpBarCount
+    });
+  }
+
+  const localMimicTimer = Number.isFinite(game.necromancerRuntime?.mimicTimer) ? game.necromancerRuntime.mimicTimer : 0;
+  const remoteMimics = (Array.isArray(game.remotePlayers) ? game.remotePlayers : [])
+    .filter((player) => player?.classType === "necromancer" && (player.necromancerRuntime?.mimicTimer || 0) > 0);
+  if (localMimicTimer > 0 || remoteMimics.length > 0) {
+    recordNetworkStateAnomaly(game, "playerMimicRuntimeVisible", {
+      keyframe: !!keyframe,
+      ackSeq: Number.isFinite(ackSeq) ? ackSeq : 0,
+      localMimicTimer,
+      remoteMimicCount: remoteMimics.length,
+      remotePlayerIds: remoteMimics.map((player) => player.id || "").filter(Boolean).slice(0, 6)
+    });
+  }
+}
+
+export function applyServerStateAnomalies(game, anomalies) {
+  if (!Array.isArray(anomalies)) return;
+  const perf = ensureNetworkPerf(game);
+  perf.recentServerStateAnomalies = anomalies
+    .filter((entry) => entry && typeof entry === "object")
+    .slice(-24)
+    .map((entry) => ({ ...entry }));
+  perf.serverStateAnomalyEventId = perf.recentServerStateAnomalies.reduce((max, entry) => {
+    const id = Number.isFinite(entry?.id) ? entry.id : 0;
+    return id > max ? id : max;
+  }, 0);
 }
 
 export function recordPostLoadCorrection(game, active, kind, errorPx, { ackSeq, pendingDepth, extra = {} } = {}) {

--- a/src/net/clientStateSync.js
+++ b/src/net/clientStateSync.js
@@ -16,6 +16,7 @@ import {
   recordCorrection,
   recordPostLoadCorrection
 } from "./clientCorrectionMetrics.js";
+import { applyPlayerSnapshotToGameState } from "./playerSnapshotSchema.js";
 export { applyMetaStateToGame } from "./clientSnapshotHelpers.js";
 
 function normalizeMapRow(row) {
@@ -363,84 +364,8 @@ export function applySnapshotToGame({
         game.player.x += dx * 0.05;
         game.player.y += dy * 0.05;
       }
-      game.player.health = snapshotPlayer.health;
-      game.player.maxHealth = snapshotPlayer.maxHealth;
-      if (Number.isFinite(snapshotPlayer.fireCooldown)) game.player.fireCooldown = snapshotPlayer.fireCooldown;
-      if (Number.isFinite(snapshotPlayer.fireArrowCooldown)) game.player.fireArrowCooldown = snapshotPlayer.fireArrowCooldown;
-      if (Number.isFinite(snapshotPlayer.deathBoltCooldown)) game.player.deathBoltCooldown = snapshotPlayer.deathBoltCooldown;
-      if (Number.isFinite(snapshotPlayer.hitCooldown)) game.player.hitCooldown = snapshotPlayer.hitCooldown;
-      if (Number.isFinite(snapshotPlayer.hpBarTimer)) game.player.hpBarTimer = snapshotPlayer.hpBarTimer;
-      game.player.classType = snapshotPlayer.classType;
-      if (typeof snapshotPlayer.classType === "string" && game.config?.classes?.[snapshotPlayer.classType]) {
-        game.classType = snapshotPlayer.classType;
-        game.classSpec = game.config.classes[snapshotPlayer.classType];
-      }
-      if (!isNetworkController) {
-        if (Number.isFinite(snapshotPlayer.dirX)) game.player.dirX = snapshotPlayer.dirX;
-        if (Number.isFinite(snapshotPlayer.dirY)) game.player.dirY = snapshotPlayer.dirY;
-        if (Number.isFinite(snapshotPlayer.facing)) game.player.facing = snapshotPlayer.facing;
-      }
     }
-    if (Number.isFinite(snapshotPlayer.level)) game.level = snapshotPlayer.level;
-    if (Number.isFinite(snapshotPlayer.score)) game.score = snapshotPlayer.score;
-    if (Number.isFinite(snapshotPlayer.gold)) game.gold = snapshotPlayer.gold;
-    if (Number.isFinite(snapshotPlayer.experience)) game.experience = snapshotPlayer.experience;
-    if (Number.isFinite(snapshotPlayer.expToNextLevel)) game.expToNextLevel = snapshotPlayer.expToNextLevel;
-    if (Number.isFinite(snapshotPlayer.skillPoints)) game.skillPoints = snapshotPlayer.skillPoints;
-    if (Number.isFinite(snapshotPlayer.refundCount)) game.refundCount = snapshotPlayer.refundCount;
-    if (Number.isFinite(snapshotPlayer.levelWeaponDamageBonus)) game.levelWeaponDamageBonus = snapshotPlayer.levelWeaponDamageBonus;
-    if (Number.isFinite(snapshotPlayer.lanternFuel)) game.player.lanternFuel = snapshotPlayer.lanternFuel;
-    if (Number.isFinite(snapshotPlayer.warriorMomentumTimer)) game.warriorMomentumTimer = snapshotPlayer.warriorMomentumTimer;
-    if (Number.isFinite(snapshotPlayer.warriorRageActiveTimer)) game.warriorRageActiveTimer = snapshotPlayer.warriorRageActiveTimer;
-    if (Number.isFinite(snapshotPlayer.warriorRageCooldownTimer)) game.warriorRageCooldownTimer = snapshotPlayer.warriorRageCooldownTimer;
-    if (Number.isFinite(snapshotPlayer.warriorRageVictoryRushPool)) game.warriorRageVictoryRushPool = snapshotPlayer.warriorRageVictoryRushPool;
-    if (Number.isFinite(snapshotPlayer.warriorRageVictoryRushTimer)) game.warriorRageVictoryRushTimer = snapshotPlayer.warriorRageVictoryRushTimer;
-    if (snapshotPlayer.necromancerBeam && typeof snapshotPlayer.necromancerBeam === "object") {
-      game.necromancerBeam = {
-        ...(game.necromancerBeam && typeof game.necromancerBeam === "object" ? game.necromancerBeam : {}),
-        ...snapshotPlayer.necromancerBeam
-      };
-    } else if (game.necromancerBeam && typeof game.necromancerBeam === "object") {
-      game.necromancerBeam.active = false;
-      game.necromancerBeam.targetId = null;
-      game.necromancerBeam.progress = 0;
-    }
-    if (snapshotPlayer.skills && typeof snapshotPlayer.skills === "object") game.skills = syncNamedObject(game.skills, snapshotPlayer.skills);
-    if (snapshotPlayer.rangerTalents && typeof snapshotPlayer.rangerTalents === "object") {
-      game.rangerTalents = syncNamedObject(game.rangerTalents, snapshotPlayer.rangerTalents);
-      if (game.player) game.player.rangerTalents = game.rangerTalents;
-    }
-    if (snapshotPlayer.warriorTalents && typeof snapshotPlayer.warriorTalents === "object") {
-      game.warriorTalents = syncNamedObject(game.warriorTalents, snapshotPlayer.warriorTalents);
-      if (game.player) game.player.warriorTalents = game.warriorTalents;
-    }
-    if (snapshotPlayer.necromancerTalents && typeof snapshotPlayer.necromancerTalents === "object") {
-      game.necromancerTalents = syncNamedObject(game.necromancerTalents, snapshotPlayer.necromancerTalents);
-      if (game.player) game.player.necromancerTalents = game.necromancerTalents;
-    }
-    if (snapshotPlayer.rangerRuntime && typeof snapshotPlayer.rangerRuntime === "object") {
-      game.rangerRuntime = syncNamedObject(game.rangerRuntime, snapshotPlayer.rangerRuntime);
-      if (game.player) game.player.rangerRuntime = game.rangerRuntime;
-    }
-    if (snapshotPlayer.warriorRuntime && typeof snapshotPlayer.warriorRuntime === "object") {
-      game.warriorRuntime = syncNamedObject(game.warriorRuntime, snapshotPlayer.warriorRuntime);
-      if (game.player) game.player.warriorRuntime = game.warriorRuntime;
-    }
-    if (snapshotPlayer.necromancerRuntime && typeof snapshotPlayer.necromancerRuntime === "object") {
-      game.necromancerRuntime = syncNamedObject(game.necromancerRuntime, snapshotPlayer.necromancerRuntime);
-      if (game.player) game.player.necromancerRuntime = game.necromancerRuntime;
-    }
-    if (snapshotPlayer.upgrades && typeof snapshotPlayer.upgrades === "object") game.upgrades = syncNamedObject(game.upgrades, snapshotPlayer.upgrades);
-    if (snapshotPlayer.consumableRuntime && typeof snapshotPlayer.consumableRuntime === "object") {
-      game.player.consumableRuntime = syncNamedObject(game.player.consumableRuntime, snapshotPlayer.consumableRuntime);
-    }
-    if (snapshotPlayer.consumables && typeof snapshotPlayer.consumables === "object") {
-      game.consumables = syncNamedObject(game.consumables, snapshotPlayer.consumables);
-    }
-    if (typeof snapshotPlayer.classType === "string" && game.config?.classes?.[snapshotPlayer.classType]) {
-      game.classType = snapshotPlayer.classType;
-      game.classSpec = game.config.classes[snapshotPlayer.classType];
-    }
+    applyPlayerSnapshotToGameState(game, snapshotPlayer, { isNetworkController, syncNamedObject });
   }
   syncRemotePlayers(game, state, localPlayerId, 0.72, syncByIdLerp);
   queuePlayerDeathNotifications(game, previousAliveById, snapshotPlayer, game.remotePlayers);

--- a/src/net/clientStateSync.js
+++ b/src/net/clientStateSync.js
@@ -14,6 +14,7 @@ import {
   ensureNetworkPerf,
   isPostLoadCorrectionActive,
   recordCorrection,
+  recordNetworkFlightEvent,
   recordPostLoadCorrection
 } from "./clientCorrectionMetrics.js";
 import { applyPlayerSnapshotToGameState } from "./playerSnapshotSchema.js";
@@ -249,6 +250,17 @@ export function applySnapshotToGame({
   const snapshotPlayer = snapshotLocalPlayer || state.player;
 
   if (snapshotPlayer && typeof snapshotPlayer === "object") {
+    const beforeFlightX = Number.isFinite(game.player?.x) ? game.player.x : null;
+    const beforeFlightY = Number.isFinite(game.player?.y) ? game.player.y : null;
+    const serverFlightX = Number.isFinite(snapshotPlayer.x) ? snapshotPlayer.x : null;
+    const serverFlightY = Number.isFinite(snapshotPlayer.y) ? snapshotPlayer.y : null;
+    let flightCorrectionKind = "none";
+    let flightCorrectionPx = serverFlightX !== null && serverFlightY !== null && beforeFlightX !== null && beforeFlightY !== null
+      ? Math.hypot(serverFlightX - beforeFlightX, serverFlightY - beforeFlightY)
+      : 0;
+    let flightAppliedPx = 0;
+    let flightPendingDepth = Array.isArray(netPendingInputs) ? netPendingInputs.length : 0;
+    let flightPostLoadActive = false;
     if (!controller) {
       Object.assign(game.player, snapshotPlayer);
     } else {
@@ -294,6 +306,7 @@ export function applySnapshotToGame({
       const jitterMs = Number.isFinite(snapshotJitterMs) ? Math.max(0, snapshotJitterMs) : 0;
       const frameGap = Number.isFinite(frameGapMs) ? Math.max(0, frameGapMs) : 16.67;
       const pendingDepth = Array.isArray(netPendingInputs) ? netPendingInputs.length : 0;
+      flightPendingDepth = pendingDepth;
       const jitterFactor = Math.max(0, Math.min(2.5, jitterMs / 8));
       const gapFactor = Math.max(0, Math.min(2, (frameGap - 16.67) / 20));
       const pendingFactor = Math.max(0, Math.min(1.5, pendingDepth / 60));
@@ -307,6 +320,7 @@ export function applySnapshotToGame({
           ? !game.isPositionWalkable(game.player.x, game.player.y, localPlayerRadius, true)
           : false;
       const postLoadCorrectionActive = isPostLoadCorrectionActive(game, { controller, ackSeq, isInitialControllerSync });
+      flightPostLoadActive = postLoadCorrectionActive;
       if (postLoadCorrectionActive) {
         game.networkPerf.postLoadLastCorrectionPx = errorDist;
         if (errorDist > (game.networkPerf.postLoadMaxCorrectionPx || 0)) {
@@ -315,7 +329,10 @@ export function applySnapshotToGame({
       }
       game.networkPerf.lastCorrectionPx = errorDist;
       if (errorDist > game.networkPerf.maxCorrectionPx) game.networkPerf.maxCorrectionPx = errorDist;
+      flightCorrectionPx = errorDist;
       if (isInitialControllerSync || localPlayerBlocked || errorDist > hardSnapDist) {
+        flightCorrectionKind = localPlayerBlocked ? "blockedHardSnap" : "hardSnap";
+        flightAppliedPx = errorDist;
         game.networkPerf.hardSnapCount += 1;
         if (postLoadCorrectionActive) game.networkPerf.postLoadHardSnapCount += 1;
         if (localPlayerBlocked) game.networkPerf.blockedSnapCount += 1;
@@ -324,21 +341,22 @@ export function applySnapshotToGame({
           ackSeq,
           pendingInputs: netPendingInputs,
           extra: {
-          correctedX: Math.round(correctedX),
-          correctedY: Math.round(correctedY)
+            correctedX: Math.round(correctedX),
+            correctedY: Math.round(correctedY)
           }
         });
         recordPostLoadCorrection(game, postLoadCorrectionActive, localPlayerBlocked ? "blockedHardSnap" : "hardSnap", errorDist, {
           ackSeq,
           pendingDepth,
           extra: {
-          correctedX: Math.round(correctedX),
-          correctedY: Math.round(correctedY)
+            correctedX: Math.round(correctedX),
+            correctedY: Math.round(correctedY)
           }
         });
         game.player.x = correctedX;
         game.player.y = correctedY;
       } else if (ackSeq > 0 && errorDist > softSnapDist) {
+        flightCorrectionKind = "softCorrection";
         game.networkPerf.softCorrectionCount += 1;
         if (postLoadCorrectionActive) game.networkPerf.postLoadSoftCorrectionCount += 1;
         recordCorrection(game, "softCorrection", errorDist, { ackSeq, pendingInputs: netPendingInputs });
@@ -351,12 +369,15 @@ export function applySnapshotToGame({
         const blend = (baseBlend + (maxBlend - baseBlend) * errorNorm) * jitterDamping;
         const maxStep = Math.max(settleDist, errorDist * 0.34);
         const step = Math.min(maxStep, errorDist * blend);
+        flightAppliedPx = step;
         if (errorDist > 0.0001) {
           const inv = 1 / errorDist;
           game.player.x += dx * inv * step;
           game.player.y += dy * inv * step;
         }
       } else if (ackSeq > 0 && errorDist > settleDist) {
+        flightCorrectionKind = "settleCorrection";
+        flightAppliedPx = errorDist * 0.05;
         game.networkPerf.settleCorrectionCount += 1;
         if (postLoadCorrectionActive) game.networkPerf.postLoadSettleCorrectionCount += 1;
         recordCorrection(game, "settleCorrection", errorDist, { ackSeq, pendingInputs: netPendingInputs });
@@ -366,6 +387,27 @@ export function applySnapshotToGame({
       }
     }
     applyPlayerSnapshotToGameState(game, snapshotPlayer, { isNetworkController, syncNamedObject });
+    recordNetworkFlightEvent(game, "snapshotApply", {
+      snapshotCount: game.networkPerf.appliedSnapshotCount || 0,
+      controller: !!controller,
+      localController: !!isNetworkController,
+      initialSync: isInitialControllerSync,
+      postLoadActive: flightPostLoadActive,
+      keyframe: !!state?.delta?.keyframe,
+      ackSeq: Number.isFinite(ackSeq) ? ackSeq : 0,
+      pendingInputs: flightPendingDepth,
+      jitterMs: Number.isFinite(snapshotJitterMs) ? Math.round(snapshotJitterMs) : 0,
+      frameGapMs: Number.isFinite(frameGapMs) ? Math.round(frameGapMs) : 0,
+      correctionKind: flightCorrectionKind,
+      correctionPx: Math.round(flightCorrectionPx),
+      appliedPx: Math.round(flightAppliedPx),
+      beforeX: beforeFlightX === null ? null : Math.round(beforeFlightX),
+      beforeY: beforeFlightY === null ? null : Math.round(beforeFlightY),
+      serverX: serverFlightX === null ? null : Math.round(serverFlightX),
+      serverY: serverFlightY === null ? null : Math.round(serverFlightY),
+      afterX: Number.isFinite(game.player?.x) ? Math.round(game.player.x) : null,
+      afterY: Number.isFinite(game.player?.y) ? Math.round(game.player.y) : null
+    });
   }
   syncRemotePlayers(game, state, localPlayerId, 0.72, syncByIdLerp);
   queuePlayerDeathNotifications(game, previousAliveById, snapshotPlayer, game.remotePlayers);

--- a/src/net/clientStateSync.js
+++ b/src/net/clientStateSync.js
@@ -13,9 +13,11 @@ import {
 import {
   ensureNetworkPerf,
   isPostLoadCorrectionActive,
+  applyServerStateAnomalies,
   recordCorrection,
   recordNetworkFlightEvent,
-  recordPostLoadCorrection
+  recordPostLoadCorrection,
+  recordSuspiciousNetworkState
 } from "./clientCorrectionMetrics.js";
 import { applyPlayerSnapshotToGameState } from "./playerSnapshotSchema.js";
 export { applyMetaStateToGame } from "./clientSnapshotHelpers.js";
@@ -223,6 +225,7 @@ function applyDeltaCollection(target, delta, { keyframe = false, positionAlpha =
   for (const item of existing.values()) target.push(item);
   return target;
 }
+
 export function applySnapshotToGame({
   game,
   state,
@@ -238,6 +241,7 @@ export function applySnapshotToGame({
 }) {
   if (!state || typeof state !== "object") return { netPendingInputs, netLastAckSeq };
   applyMetaStateToGame(game, state);
+  applyServerStateAnomalies(game, state.serverStateAnomalies);
   const previousAliveById = new Map();
   if (game?.player?.id) previousAliveById.set(game.player.id, (game.player.alive !== false) && (game.player.health || 0) > 0);
   for (const player of Array.isArray(game?.remotePlayers) ? game.remotePlayers : []) {
@@ -448,6 +452,7 @@ export function applySnapshotToGame({
     game.fireZones = applyDeltaCollection(game.fireZones, state.delta.fireZones, { keyframe, positionAlpha: 1 });
     game.meleeSwings = applyDeltaCollection(game.meleeSwings, state.delta.meleeSwings, { keyframe, positionAlpha: 1 });
     synthesizeEnemyDamageFloatingTexts(game, previousEnemyStateById, { skip: keyframe });
+    recordSuspiciousNetworkState(game, { keyframe, ackSeq });
   } else {
     game.armorStands = syncByIdLerp(game.armorStands, state.armorStands, 1);
     game.enemies = syncByIdLerp(game.enemies, state.enemies, snapAlpha);
@@ -460,6 +465,7 @@ export function applySnapshotToGame({
     game.fireZones = syncByIdLerp(game.fireZones, state.fireZones, 1);
     game.meleeSwings = syncByIdLerp(game.meleeSwings, state.meleeSwings, 1);
     synthesizeEnemyDamageFloatingTexts(game, previousEnemyStateById, { skip: false });
+    recordSuspiciousNetworkState(game, { keyframe: false, ackSeq });
   }
 
   return { netPendingInputs, netLastAckSeq };

--- a/src/net/playerSnapshotSchema.js
+++ b/src/net/playerSnapshotSchema.js
@@ -1,0 +1,190 @@
+export const PLAYER_SNAPSHOT_FIELDS = [
+  "x",
+  "y",
+  "size",
+  "health",
+  "maxHealth",
+  "hpBarTimer",
+  "level",
+  "score",
+  "gold",
+  "experience",
+  "expToNextLevel",
+  "skillPoints",
+  "refundCount",
+  "levelWeaponDamageBonus",
+  "lanternFuel",
+  "skills",
+  "rangerTalents",
+  "warriorTalents",
+  "necromancerTalents",
+  "rangerRuntime",
+  "warriorRuntime",
+  "necromancerRuntime",
+  "consumableRuntime",
+  "consumables",
+  "upgrades",
+  "dirX",
+  "dirY",
+  "facing",
+  "classType"
+];
+
+export const ACTIVE_PLAYER_SNAPSHOT_FIELDS = [
+  "id",
+  "handle",
+  "classType",
+  "x",
+  "y",
+  "size",
+  "health",
+  "maxHealth",
+  "hpBarTimer",
+  "level",
+  "score",
+  "gold",
+  "experience",
+  "expToNextLevel",
+  "skillPoints",
+  "refundCount",
+  "levelWeaponDamageBonus",
+  "lanternFuel",
+  "fireCooldown",
+  "fireArrowCooldown",
+  "deathBoltCooldown",
+  "warriorMomentumTimer",
+  "warriorRageActiveTimer",
+  "warriorRageCooldownTimer",
+  "warriorRageVictoryRushPool",
+  "warriorRageVictoryRushTimer",
+  "skills",
+  "rangerTalents",
+  "warriorTalents",
+  "necromancerTalents",
+  "upgrades",
+  "consumableRuntime",
+  "consumables",
+  "rangerRuntime",
+  "warriorRuntime",
+  "necromancerRuntime",
+  "dirX",
+  "dirY",
+  "facing",
+  "moving",
+  "alive",
+  "spectateTargetId",
+  "color"
+];
+
+function copySnapshotFields(source, fields) {
+  const out = {};
+  for (const field of fields) out[field] = source?.[field];
+  if (!Number.isFinite(out.hpBarTimer)) out.hpBarTimer = 0;
+  return out;
+}
+
+export function createNecromancerBeamSnapshot(beam) {
+  if (!beam) return null;
+  return {
+    active: !!beam.active,
+    targetId: typeof beam.targetId === "string" ? beam.targetId : null,
+    targetX: Number.isFinite(beam.targetX) ? beam.targetX : 0,
+    targetY: Number.isFinite(beam.targetY) ? beam.targetY : 0,
+    progress: Number.isFinite(beam.progress) ? beam.progress : 0
+  };
+}
+
+export function createPlayerSnapshot(player) {
+  return copySnapshotFields(player, PLAYER_SNAPSHOT_FIELDS);
+}
+
+export function createActivePlayerSnapshot(player) {
+  const out = copySnapshotFields(player, ACTIVE_PLAYER_SNAPSHOT_FIELDS);
+  out.necromancerBeam = createNecromancerBeamSnapshot(player?.necromancerBeam);
+  out.moving = !!player?.moving;
+  out.alive = player?.alive !== false;
+  out.spectateTargetId = typeof player?.spectateTargetId === "string" ? player.spectateTargetId : "";
+  return out;
+}
+
+export function applyPlayerSnapshotToGameState(game, snapshotPlayer, { isNetworkController = false, syncNamedObject } = {}) {
+  if (!game || !snapshotPlayer || typeof snapshotPlayer !== "object") return;
+  if (Number.isFinite(snapshotPlayer.health)) game.player.health = snapshotPlayer.health;
+  if (Number.isFinite(snapshotPlayer.maxHealth)) game.player.maxHealth = snapshotPlayer.maxHealth;
+  if (Number.isFinite(snapshotPlayer.fireCooldown)) game.player.fireCooldown = snapshotPlayer.fireCooldown;
+  if (Number.isFinite(snapshotPlayer.fireArrowCooldown)) game.player.fireArrowCooldown = snapshotPlayer.fireArrowCooldown;
+  if (Number.isFinite(snapshotPlayer.deathBoltCooldown)) game.player.deathBoltCooldown = snapshotPlayer.deathBoltCooldown;
+  if (Number.isFinite(snapshotPlayer.hitCooldown)) game.player.hitCooldown = snapshotPlayer.hitCooldown;
+  if (Number.isFinite(snapshotPlayer.hpBarTimer)) game.player.hpBarTimer = snapshotPlayer.hpBarTimer;
+  game.player.classType = snapshotPlayer.classType;
+  if (typeof snapshotPlayer.classType === "string" && game.config?.classes?.[snapshotPlayer.classType]) {
+    game.classType = snapshotPlayer.classType;
+    game.classSpec = game.config.classes[snapshotPlayer.classType];
+  }
+  if (!isNetworkController) {
+    if (Number.isFinite(snapshotPlayer.dirX)) game.player.dirX = snapshotPlayer.dirX;
+    if (Number.isFinite(snapshotPlayer.dirY)) game.player.dirY = snapshotPlayer.dirY;
+    if (Number.isFinite(snapshotPlayer.facing)) game.player.facing = snapshotPlayer.facing;
+  }
+  if (Number.isFinite(snapshotPlayer.level)) game.level = snapshotPlayer.level;
+  if (Number.isFinite(snapshotPlayer.score)) game.score = snapshotPlayer.score;
+  if (Number.isFinite(snapshotPlayer.gold)) game.gold = snapshotPlayer.gold;
+  if (Number.isFinite(snapshotPlayer.experience)) game.experience = snapshotPlayer.experience;
+  if (Number.isFinite(snapshotPlayer.expToNextLevel)) game.expToNextLevel = snapshotPlayer.expToNextLevel;
+  if (Number.isFinite(snapshotPlayer.skillPoints)) game.skillPoints = snapshotPlayer.skillPoints;
+  if (Number.isFinite(snapshotPlayer.refundCount)) game.refundCount = snapshotPlayer.refundCount;
+  if (Number.isFinite(snapshotPlayer.levelWeaponDamageBonus)) game.levelWeaponDamageBonus = snapshotPlayer.levelWeaponDamageBonus;
+  if (Number.isFinite(snapshotPlayer.lanternFuel)) game.player.lanternFuel = snapshotPlayer.lanternFuel;
+  if (Number.isFinite(snapshotPlayer.warriorMomentumTimer)) game.warriorMomentumTimer = snapshotPlayer.warriorMomentumTimer;
+  if (Number.isFinite(snapshotPlayer.warriorRageActiveTimer)) game.warriorRageActiveTimer = snapshotPlayer.warriorRageActiveTimer;
+  if (Number.isFinite(snapshotPlayer.warriorRageCooldownTimer)) game.warriorRageCooldownTimer = snapshotPlayer.warriorRageCooldownTimer;
+  if (Number.isFinite(snapshotPlayer.warriorRageVictoryRushPool)) game.warriorRageVictoryRushPool = snapshotPlayer.warriorRageVictoryRushPool;
+  if (Number.isFinite(snapshotPlayer.warriorRageVictoryRushTimer)) game.warriorRageVictoryRushTimer = snapshotPlayer.warriorRageVictoryRushTimer;
+  if (snapshotPlayer.necromancerBeam && typeof snapshotPlayer.necromancerBeam === "object") {
+    game.necromancerBeam = {
+      ...(game.necromancerBeam && typeof game.necromancerBeam === "object" ? game.necromancerBeam : {}),
+      ...snapshotPlayer.necromancerBeam
+    };
+  } else if (game.necromancerBeam && typeof game.necromancerBeam === "object") {
+    game.necromancerBeam.active = false;
+    game.necromancerBeam.targetId = null;
+    game.necromancerBeam.progress = 0;
+  }
+  if (typeof syncNamedObject !== "function") return;
+  if (snapshotPlayer.skills && typeof snapshotPlayer.skills === "object") game.skills = syncNamedObject(game.skills, snapshotPlayer.skills);
+  if (snapshotPlayer.rangerTalents && typeof snapshotPlayer.rangerTalents === "object") {
+    game.rangerTalents = syncNamedObject(game.rangerTalents, snapshotPlayer.rangerTalents);
+    if (game.player) game.player.rangerTalents = game.rangerTalents;
+  }
+  if (snapshotPlayer.warriorTalents && typeof snapshotPlayer.warriorTalents === "object") {
+    game.warriorTalents = syncNamedObject(game.warriorTalents, snapshotPlayer.warriorTalents);
+    if (game.player) game.player.warriorTalents = game.warriorTalents;
+  }
+  if (snapshotPlayer.necromancerTalents && typeof snapshotPlayer.necromancerTalents === "object") {
+    game.necromancerTalents = syncNamedObject(game.necromancerTalents, snapshotPlayer.necromancerTalents);
+    if (game.player) game.player.necromancerTalents = game.necromancerTalents;
+  }
+  if (snapshotPlayer.rangerRuntime && typeof snapshotPlayer.rangerRuntime === "object") {
+    game.rangerRuntime = syncNamedObject(game.rangerRuntime, snapshotPlayer.rangerRuntime);
+    if (game.player) game.player.rangerRuntime = game.rangerRuntime;
+  }
+  if (snapshotPlayer.warriorRuntime && typeof snapshotPlayer.warriorRuntime === "object") {
+    game.warriorRuntime = syncNamedObject(game.warriorRuntime, snapshotPlayer.warriorRuntime);
+    if (game.player) game.player.warriorRuntime = game.warriorRuntime;
+  }
+  if (snapshotPlayer.necromancerRuntime && typeof snapshotPlayer.necromancerRuntime === "object") {
+    game.necromancerRuntime = syncNamedObject(game.necromancerRuntime, snapshotPlayer.necromancerRuntime);
+    if (game.player) game.player.necromancerRuntime = game.necromancerRuntime;
+  }
+  if (snapshotPlayer.upgrades && typeof snapshotPlayer.upgrades === "object") game.upgrades = syncNamedObject(game.upgrades, snapshotPlayer.upgrades);
+  if (snapshotPlayer.consumableRuntime && typeof snapshotPlayer.consumableRuntime === "object") {
+    game.player.consumableRuntime = syncNamedObject(game.player.consumableRuntime, snapshotPlayer.consumableRuntime);
+  }
+  if (snapshotPlayer.consumables && typeof snapshotPlayer.consumables === "object") {
+    game.consumables = syncNamedObject(game.consumables, snapshotPlayer.consumables);
+  }
+  if (typeof snapshotPlayer.classType === "string" && game.config?.classes?.[snapshotPlayer.classType]) {
+    game.classType = snapshotPlayer.classType;
+    game.classSpec = game.config.classes[snapshotPlayer.classType];
+  }
+}

--- a/src/net/projectilePrediction.js
+++ b/src/net/projectilePrediction.js
@@ -1,5 +1,8 @@
 import { getRangerCurrentWeaponModeStats, getRangerSelectedWeapon } from "../game/rangerTalentTree.js";
 
+const PREDICTIVE_RANGED_PROJECTILES_ENABLED = false;
+const PREDICTIVE_MELEE_SWINGS_ENABLED = false;
+
 function removeRenderedPredictedProjectile(game, renderId) {
   if (!game || typeof renderId !== "string" || !renderId) return;
   for (const collection of [game.bullets, game.fireArrows, game.meleeSwings]) {
@@ -240,6 +243,8 @@ export function predictProjectileSpawn(game, input, nowMs, isNetworkController, 
   const dirY = rawY / len;
   const usesRanged = !!game.classSpec?.usesRanged;
   if (usesRanged && typeof game.getBowMuzzleOrigin !== "function") return nextHeldPrimaryPredictAtMs;
+  if (usesRanged && !PREDICTIVE_RANGED_PROJECTILES_ENABLED) return 0;
+  if (!usesRanged && !PREDICTIVE_MELEE_SWINGS_ENABLED) return 0;
 
   const primaryCdSec = typeof game.getPlayerFireCooldown === "function" ? game.getPlayerFireCooldown() : 0.25;
   const primaryCadenceMs = Math.max(40, (Number.isFinite(primaryCdSec) ? primaryCdSec : 0.25) * 1000);

--- a/src/rendering/rendererEffectsPlayerMethods.js
+++ b/src/rendering/rendererEffectsPlayerMethods.js
@@ -48,6 +48,12 @@ export const rendererEffectsPlayerMethods = {
     return this.config.classes[classType] || this.config.classes.archer;
   },
 
+  getReplicatedPlayerFirePulse(player) {
+    const fireCooldown = Number.isFinite(player?.fireCooldown) ? player.fireCooldown : 0;
+    const baseCd = Number.isFinite(this.config?.player?.baseFireCooldown) ? this.config.player.baseFireCooldown : 0;
+    return baseCd > 0 ? Math.max(0, Math.min(1, fireCooldown / baseCd)) : 0;
+  },
+
   drawReplicatedPlayerSprite(player, screenX, screenY, renderSize, frameSize) {
     const prevRenderX = Number.isFinite(player._renderPrevX) ? player._renderPrevX : player.x;
     const prevRenderY = Number.isFinite(player._renderPrevY) ? player._renderPrevY : player.y;
@@ -101,18 +107,19 @@ export const rendererEffectsPlayerMethods = {
     const usesRanged = !!classSpec?.usesRanged;
     const doctrine = getWarriorDoctrine(player);
     const doctrineVisual = this.getWarriorDoctrinePresentation(player);
+    const firePulse = this.getReplicatedPlayerFirePulse(player);
     if (player.classType === "necromancer") {
-      this.drawPlayerNecromancerRig(player, screenX, screenY, walkPhase, 0);
+      this.drawPlayerNecromancerRig(player, screenX, screenY, walkPhase, firePulse);
       return;
     }
     if (!usesRanged) {
       if ((player?.warriorRageActiveTimer || 0) > 0) this.ctx.save();
       if ((player?.warriorRageActiveTimer || 0) > 0) this.ctx.filter = doctrineVisual.filter;
-      this.drawPlayerFighterRig(player, screenX, screenY, walkPhase, 0);
+      this.drawPlayerFighterRig(player, screenX, screenY, walkPhase, firePulse);
       if ((player?.warriorRageActiveTimer || 0) > 0) this.ctx.restore();
       return;
     }
-    this.drawPlayerAimingRig(player, screenX, screenY, walkPhase, 0, this.getRangerWeaponPresentation(player));
+    this.drawPlayerAimingRig(player, screenX, screenY, walkPhase, firePulse, this.getRangerWeaponPresentation(player));
   },
 
   drawRemotePlayerHandle(player, screenX, screenY) {

--- a/src/rendering/rendererEffectsProjectileMethods.js
+++ b/src/rendering/rendererEffectsProjectileMethods.js
@@ -19,7 +19,7 @@ export const rendererEffectsProjectileMethods = {
   drawProjectiles(game, cameraX, cameraY) {
     const ctx = this.ctx;
     for (const swing of game.meleeSwings || []) {
-      this.drawMeleeSwing(swing, cameraX, cameraY, game.player);
+      this.drawMeleeSwing(swing, cameraX, cameraY);
     }
 
     if (game.necromancerBeam?.active) {
@@ -515,7 +515,7 @@ export const rendererEffectsProjectileMethods = {
     ctx.restore();
   },
 
-  drawMeleeSwing(swing, cameraX, cameraY, player) {
+  drawMeleeSwing(swing, cameraX, cameraY) {
     const ctx = this.ctx;
     const life = Number.isFinite(swing.life) ? swing.life : 0;
     const maxLife = Number.isFinite(swing.maxLife) && swing.maxLife > 0 ? swing.maxLife : this.config.effects.meleeSwingLife;
@@ -530,7 +530,6 @@ export const rendererEffectsProjectileMethods = {
     const end = swing.angle + arc * 0.5;
     const dirX = Math.cos(swing.angle);
     const dirY = Math.sin(swing.angle);
-    const originPlayer = player && Number.isFinite(player.x) && Number.isFinite(player.y) ? player : null;
     if (![x, y, range, arc, start, end, dirX, dirY].every(Number.isFinite)) return;
     const style = typeof swing.style === "string" ? swing.style : "broadswing";
     const modifier = typeof swing.modifier === "string" ? swing.modifier : "";
@@ -718,9 +717,9 @@ export const rendererEffectsProjectileMethods = {
     const bladeY = y + dirY * (range * 0.72);
     ctx.strokeStyle = swing.executeProc ? "#ffd0d0" : "#e9e0d1";
     ctx.lineWidth = swing.executeProc ? 2.3 : 2;
-    if (originPlayer && style !== "warWhip" && style !== "twinHatchets") {
+    if (style !== "warWhip" && style !== "twinHatchets") {
       ctx.beginPath();
-      ctx.moveTo(originPlayer.x - cameraX + dirX * 12, originPlayer.y - cameraY + dirY * 12);
+      ctx.moveTo(x + dirX * 12, y + dirY * 12);
       ctx.lineTo(bladeX, bladeY);
       ctx.stroke();
     }


### PR DESCRIPTION
  - Added server-side state anomaly telemetry for enemy status fanout, player mimic visibility, class
    mismatches, and negative tick deltas.
  - Fixed authoritative tick corruption by clamping server dt to [0, 0.05], preventing negative deltas from
    inventing status/mimic timers.
  - Preserved server anomaly data through snapshots, client state sync, debug dumps, and dev telemetry.
  - Fixed multiplayer melee swing VFX anchoring so remote warrior swing lines start from the swing origin
    instead of the local player.
  - Disabled local predictive ranged projectiles and predictive melee swing VFX so combat visuals come from
    authoritative snapshots.
  - Added/updated validation coverage for state corruption, VFX serialization/rendering, player state sync,
    telemetry, pause behavior, and network regressions.